### PR TITLE
Last year of updates on ItMightBeKaraoke branch

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,38 +1,41 @@
 {
-    "globals": {
+	"globals": {
 		"__": true
-    },
-    "env": {
-        "es6": true,
+	},
+	"env": {
+		"es6": true,
 		"node": true,
 		"mocha":true
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
+	},
+	"plugins": [
+		"@typescript-eslint"
+	],
+	"rules": {
 		"jsx-a11y/href-no-hash": [0],
-        "brace-style": [
-            "error",
-            "1tbs"
-        ],
-        "no-console": 0,
-        "indent": [
-            "error",
-            "tab"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "no-throw-literal": "off"
-    },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "sourceType": "module"
-    }
+		"brace-style": [
+			"error",
+			"1tbs"
+		],
+		"no-console": 0,
+		"indent": [
+			"error",
+			"tab"
+		],
+		"quotes": [
+			"error",
+			"double",
+			{
+				"avoidEscape": true
+			}
+		],
+		"semi": [
+			"error",
+			"always"
+		],
+		"no-throw-literal": "off"
+	},
+	"parser": "@typescript-eslint/parser",
+	"parserOptions": {
+		"sourceType": "module"
+	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # CHANGELOG
 
+## 1.1.1
+
+Ensure behavior matches upstream by default where possible (except in the case of bugs)
+
+## 1.1.0
+
+Numerous updates to add various KBS functionality and CLI options
+
 ## 1.0.1
-- minimum_progression_duration is now 1 second by default
+- minimum\_progression\_duration is now 1 second by default
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,22 @@ Options are :
 
 ```JS
 {
-  'syllable_precision': boolean,
-  'minimum_progression_duration': number,
+  'syllable-precision': boolean,
+  'minimum-progression-duration': number,
   'cdg': boolean,
   'wipe': boolean,
   'position': boolean,
-  'border': boolean
+  'border': boolean,
+  'width': number,
+  'transparency': boolean,
+  'dialogueScript': string, // Specify custom prefix used on all lines, e.g. custom fade in/out values
+  'offset': number,
+  'display': number,
+  'remove': number
 }
 ```
 
-See details of these options from the matching options in the CLI section below.
+See details of these options from the matching options in the CLI section below. There's a comment on the dialogueScript option because its matching option is the non-obvious --fade, and it's more flexible. The fadeToDialogueScript function can be used to convert from the fade string format in the CLI.
 
 ### CLI
 
@@ -47,7 +53,7 @@ kbp2ass [options] infile minimum-progression-duration [--] [outfile]
 
 Convert file from KBS project format (.kbp) to SubStation Alpha subtitle (.ass)
 
-infile:	input file in .kbp format (stdin if not specified)
+infile:  input file in .kbp format (stdin if not specified)
 outfile: output file in .ass format (stdout if not specified)
 
 For compatibility with older releases, minimum-progression-duration can be specified as a positional parameter instead of an option (if both are
@@ -57,24 +63,49 @@ disable this functionality.
 Disable any boolean option with --no-[option]
 
 Options:
-      --help                                            Show help
-      --version                                         Show version number
+      --help                                            Show help                                                                        [boolean]
+      --version                                         Show version number                                                              [boolean]
   -s, --syllable-precision                              Highlight syllables individually instead of combining lines into a single string.
-                                                        Disabling this is not recommended. (default: true)
+                                                        Disabling this is not recommended.                               [boolean] [default: true]
   -m, --minimum-progression-duration, --wipe-threshold  Set threshold of syllable display time in milliseconds before using progressive wipe
-                                                        effect (implicit default 1000)
+                                                        effect (implicit default 1000)                                                    [number]
   -f, --full-mode                                       Enable processing of all positional and style information in the KBS project file (-w, -p,
-                                                        -b, -c). To unset any particular options use --no-{option}. For example, to run in full
-                                                        mode but with no border set, use "-f --no-b" or "--full-mode --no-border".
+                                                        -b, -c, -t, -D -1). To unset any particular options use --no-{option}. For example, to run
+                                                        in full mode but with no border set, use "-f --no-b" or "--full-mode --no-border".
+                                                                                                                                         [boolean]
   -c, --cdg                                             Set the virtual resolution of the destination file to that of CDG graphics, enabling
-                                                        positioning, alignment, and font size to work as they do in KBS.
+                                                        positioning, alignment, and font size to work as they do in KBS.                 [boolean]
   -w, --wipe                                            Use wipe setting from project file (progressive wipe effect unless wiping is set to word
-                                                        by word). Sets -m to 0 if not otherwise set.
+                                                        by word). Sets -m to 0 if not otherwise set.                                     [boolean]
   -p, --position                                        Use position data from project file. This includes alignment as well as
-                                                        vertical/horizontal offset. Strongly recommended to use with -c option.
+                                                        vertical/horizontal offset. Strongly recommended to use with -c option.          [boolean]
   -b, --border                                          Use default CDG border (12 pixels from top of screen). If -c option is used, these are
                                                         virtual pixels. To use a custom border, set --no-border and add a border in your video
-                                                        editor of choice.
+                                                        editor of choice.                                                                [boolean]
+  -F, --fade                                            Fade-in/out duration for line display in milliseconds. Defaults to 300,200. If only one
+                                                        number is specified it is used for both fade in and out. If 0 or 0,0 is specified, fade
+                                                        effect is disabled entirely.                                                      [string]
+  -D, --displayremove                                   Timing for line display/remove in milliseconds. Defaults to 1000,100. Note that this time
+                                                        includes the fade, so e.g. fade in of 300 and display of 1000 means that the line fades in
+                                                        for 300ms, then continues displaying at full opacity for 700ms before wiping starts. If
+                                                        only one number is specified it is used for both display and remove. If -1 is specified
+                                                        for either parameter, display/remove timings from the .kbp are used.              [string]
+  -W, --width                                           Override the width in the virtual resolution. E.g. set to 384 to get 16:9 aspect ratio if
+                                                        border is enabled, and 341 if it's not. This only has any effect with the --cdg option
+                                                        enabled.                                                                          [number]
+  -t, --transparency                                    When using palette color 0, always treat it as transparent. This more closely models the
+                                                        behavior KBS uses when generating a CDG, because drawing in the background color XORs with
+                                                        0, thus not updating the screen. This setting will only be noticeable if you overlap text
+                                                        or render the .ass against a different background color than is defined in the kbp file
+                                                        (or overlay an image/video).                                                     [boolean]
+  -o, --offset                                          Amount of seconds to adjust the timings in the .ass file. This can be used to match the
+                                                        offset configured in the KBS Studio Settings or to add time for an intro video. A negative
+                                                        number means to adjust the timings to occur before the time specified in the .kbp file. If
+                                                        not specified, the program will attempt to read from the KBS configuration file in
+                                                        %AppData%\Karaoke Builder\data_studio.ini. If unable, it will be set to 0. Note that the
+                                                        default setting in KBS is -0.2 seconds, but it is recommended to set it to 0 to make the
+                                                        .kbp files contain the true timing. If this offset would make any display/remove or wipe
+                                                        timings negative, those become 0.                                                 [number]
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,34 @@ You might want to set `syllable_precision` to `true` to get syllable-timed karao
 
 ### CLI
 
-The CLI version is used as follows :
+The CLI version has the following usage:
 
 ```sh
-kbp2ass myfile.txt
+kbp2ass [options] [--] [infile [outfile]]
+kbp2ass [options] infile minimum-progression-duration [--] [outfile]
+
+Convert file from KBS project format (.kbp) to SubStation Alpha subtitle (.ass)
+
+infile:	input file in .kbp format (stdin if not specified)
+outfile: output file in .ass format (stdout if not specified)
+
+For compatibility with older releases, minimum-progression-duration can be specified as a positional parameter instead of an option (if both are
+specified, the positional wins). If your output file name happens to be a number, use -- at some point before the second positional parameter to
+disable this functionality.
+
+Disable any boolean option with --no-[option]
+
+Options:
+      --help                                            Show help
+      --version                                         Show version number
+  -s, --syllable-precision                              Highlight syllables individually instead of combining lines into a single string.
+                                                        Disabling this is not recommended. (default: true)
+  -m, --minimum-progression-duration, --wipe-threshold  Set threshold of syllable display time in milliseconds before using progressive wipe
+                                                        effect (implicit default 1000)
+
 ```
 
-It produces an ASS file on stdout.
+stdin support is currently only available on \*nix platforms. outfile support is not yet implemented.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Options are :
 
 ```JS
 {
-  syllable_precision: boolean,
-  minimum_progression_duration: number
-
+  'syllable_precision': boolean,
+  'minimum_progression_duration': number,
+  'cdg': boolean,
+  'wipe': boolean,
+  'position': boolean,
+  'border': boolean
 }
 ```
 
-You might want to set `syllable_precision` to `true` to get syllable-timed karaoke instead of sentence-timed karaoke
-
-`minimum_progression_duration` is a duration in milliseconds. 0 is everything is progressive syllabe.
-1000 is one second. By default, 1000
+See details of these options from the matching options in the CLI section below.
 
 ### CLI
 
@@ -63,10 +63,38 @@ Options:
                                                         Disabling this is not recommended. (default: true)
   -m, --minimum-progression-duration, --wipe-threshold  Set threshold of syllable display time in milliseconds before using progressive wipe
                                                         effect (implicit default 1000)
+  -f, --full-mode                                       Enable processing of all positional and style information in the KBS project file (-w, -p,
+                                                        -b, -c). To unset any particular options use --no-{option}. For example, to run in full
+                                                        mode but with no border set, use "-f --no-b" or "--full-mode --no-border".
+  -c, --cdg                                             Set the virtual resolution of the destination file to that of CDG graphics, enabling
+                                                        positioning, alignment, and font size to work as they do in KBS.
+  -w, --wipe                                            Use wipe setting from project file (progressive wipe effect unless wiping is set to word
+                                                        by word). Sets -m to 0 if not otherwise set.
+  -p, --position                                        Use position data from project file. This includes alignment as well as
+                                                        vertical/horizontal offset. Strongly recommended to use with -c option.
+  -b, --border                                          Use default CDG border (12 pixels from top of screen). If -c option is used, these are
+                                                        virtual pixels. To use a custom border, set --no-border and add a border in your video
+                                                        editor of choice.
 
 ```
 
 stdin support is currently only available on \*nix platforms. outfile support is not yet implemented.
+
+The recommended two usages are basic mode and full mode. Basic mode is:
+
+`kbp2ass infile.kbp`
+
+This creates an easy-to-edit .ass file with display/remove and wipe timing from the .kbp file.
+
+Full mode is:
+
+`kbp2ass -f infile.kbp`
+
+This creates a .ass file with as many kbp features as possible (which will be extended further as development continues). The intention is not to distribute this directly, as it might cause problems for some video players and is difficult to edit/read. The goal is to have a format that can be immediately hard-subbed into a video. It should be compatible with ffmpeg and anything else that uses libass. Example hard-subbing command:
+
+ffmpeg -i background-video.mp4 -vf ass=outfile.ass outfile.mp4
+
+For the cleanest wiping, 60fps video is recommended.
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "url": "https://github.com/Aeden-B/kbp2ass/kbp2ass.git"
   },
   "dependencies": {
-    "ass-stringify": "^0.1.3",
     "yargs": "^17.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "https://github.com/Aeden-B/kbp2ass/kbp2ass.git"
   },
   "dependencies": {
-    "ass-stringify": "^0.1.3"
+    "ass-stringify": "^0.1.3",
+    "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",
@@ -35,6 +36,6 @@
     "@typescript-eslint/parser": "^5.22.0",
     "eslint": "^8.14.0",
     "ts-node": "^10.7.0",
-    "typescript": "^4.6.4"
+    "typescript": "~4.8.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbp2ass",
-  "version": "1.1.1-0",
+  "version": "1.1.2",
   "description": "Convert KBP karaoke files to ASS files",
   "main": "dist/index.js",
   "types": "src/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbp2ass",
-  "version": "1.1.0-0",
+  "version": "1.1.1-0",
   "description": "Convert KBP karaoke files to ASS files",
   "main": "dist/index.js",
   "types": "src/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "kbp"
   ],
   "author": "Florent Berthelot (@Aeden_)",
+  "contributors": [
+    "Matt M"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Aeden-B/kbp2ass/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbp2ass",
-  "version": "1.0.1",
+  "version": "1.1.0-0",
   "description": "Convert KBP karaoke files to ASS files",
   "main": "dist/index.js",
   "types": "src/types.d.ts",

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -1,0 +1,143 @@
+import { clone, msToAss } from "./utils";
+import KBPParser from "./kbp";
+import stringify from "./assStringify";
+import type{
+  IStyle,
+  IConfig,
+  ISentence,
+  ISyllable,
+  IDialogueKV,
+  IStyleKV,
+  IEvents,
+} from "./types";
+import * as ass from "./assTemplate";
+
+function generateASSLine(line: ISentence, options: IConfig) {
+  const assLine = [];
+  let startMs = line.start;
+  const stopMs = line.end;
+  let firstStart = null;
+  let lastSylEnd = null;
+  let gap = null;
+  line.syllables.forEach(syl => {
+    gap =
+      lastSylEnd != null && syl.start - lastSylEnd > 10
+        ? `{\\k${(syl.start - lastSylEnd) / 10}}`
+        : "";
+    assLine.push(
+      `${gap}{\\k${getProgressive(syl, options)}${Math.floor(
+        syl.duration / 10
+      )}${syl.text}}`
+    );
+
+    if (firstStart == null) firstStart = syl.start;
+    lastSylEnd = syl.end;
+  });
+  const dialogue = clone(ass.defaultDialogue);
+
+  dialogue.value.Start = msToAss(startMs);
+  dialogue.value.End = msToAss(stopMs);
+  dialogue.value.Style = line.currentStyle;
+
+  const comment: IDialogueKV<"Comment"> = {
+    key: "Comment",
+    value: { ...dialogue.value, Text: assLine.join(""), Effect: "karaoke" },
+  };
+
+  // Horizontal offset only makes sense when there is a set number of pixels to center across
+  const hOffset = options.cdg || line.alignment != 8 ? line.hpos : 0;
+  const pos = options.position ? `\\pos(${hOffset},${line.vpos})` : "";
+
+  // TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
+  dialogue.value.Text = `\\an${line.alignment}${pos}\\k${
+    (firstStart - startMs) / 10
+  }${ass.dialogueScript}${assLine.join("")}`;
+  dialogue.value.Effect = "fx";
+
+  return {
+    dialogue,
+    comment,
+  };
+}
+
+function getProgressive(syl: ISyllable, options: IConfig) {
+  // When duration exceeds the threshold, progressive wiping may be possible
+  if (
+    Math.floor(syl.duration / 10) >
+    Math.floor(options["minimum-progression-duration"] / 10)
+  ) {
+    // If option is set to use wiping setting from the kbp file, do so, otherwise set unconditionally
+    return options.wipe && !syl.wipeProgressive ? "" : "f";
+    // If duration does not exceed the threshold, progressive wiping cannot be
+    // used, regardless of kbp setting
+  } else {
+    return "";
+  }
+}
+
+function sortStartTime<T>(a: IDialogueKV<T>, b: IDialogueKV<T>) {
+  if (a.value.Start < b.value.Start) return -1;
+  if (a.value.Start > b.value.Start) return 1;
+  return 0;
+}
+
+function getStyleAss(style: IStyle): IStyleKV {
+  return {
+    key: "Style",
+    value: {
+      ...ass.defaultStyle.value,
+      ...style,
+    },
+  };
+}
+
+/** Convert KBP data (txt) to ASS */
+export function convertToASS(time: string, options: IConfig) {
+  const kbp = new KBPParser(options);
+  const kara = kbp.parse(time);
+  const dialogues: IDialogueKV<"Dialogue">[] = [];
+  const comments: IDialogueKV<"Comment">[] = [];
+
+  const styles = clone(ass.styles);
+  styles.body = styles.body.concat(
+    kbp.styles.length > 0
+      ? kbp.styles.map(style => getStyleAss(style))
+      : [{ ...ass.defaultStyle }]
+  );
+
+  comments.push({
+    key: "Comment",
+    value: {
+      ...ass.defaultDialogue.value,
+      Effect: ass.scriptFX,
+      Text: ass.scriptFX,
+    },
+  });
+  for (const line of kara.track) {
+    const ASSLines = generateASSLine(line, options);
+    comments.push(clone(ASSLines.comment));
+    dialogues.push(clone(ASSLines.dialogue));
+  }
+  comments.sort(sortStartTime);
+  dialogues.sort(sortStartTime);
+  const events: IEvents = {
+    section: "Events",
+    body: [...ass.events.body, ...comments, ...dialogues],
+  };
+
+  const header = clone(ass.scriptInfo);
+  if (options.cdg) {
+    if (options.border) {
+      header.body.push(
+        { key: "PlayResX", value: 300 },
+        { key: "PlayResY", value: 216 }
+      );
+    } else {
+      header.body.push(
+        { key: "PlayResX", value: 288 },
+        { key: "PlayResY", value: 192 }
+      );
+    }
+  }
+  return stringify([header, styles, events]);
+}

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -50,13 +50,14 @@ function generateASSLine(line: ISentence, options: IConfig) {
   };
 
   // Horizontal offset only makes sense when there is a set number of pixels to center across
-  const hOffset = options.cdg || line.alignment != 8 ? line.hpos : 0;
+  // TODO: position = true, cdg = false, line.alignment = 0 (pull from style), style.alignment != 8 - style object currently not included in parameters
+  const hOffset = options.cdg || [0,8].includes(line.alignment) ? line.hpos : 0;
   const pos = options.position ? `\\pos(${hOffset},${line.vpos})` : "";
 	// TODO: calculate rotation origin if not left-aligned to match KBS?
 	const rot = options.position && line.rotation != 0 ? `\\frz${line.rotation}` : '';
 
   // TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
-  dialogue.value.Text = `{\\an${line.alignment}${pos}${rot}\\k${
+  dialogue.value.Text = `{${line.alignment == 0 ? '' : `\\an${line.alignment}`}${pos}${rot}\\k${
     (firstStart - startMs) / 10
   }${options.dialogueScript}}${assLine.join("")}`;
   dialogue.value.Effect = "fx";

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -19,20 +19,25 @@ function generateASSLine(line: ISentence, options: IConfig) {
   let firstStart = null;
   let lastSylEnd = null;
   let gap = null;
-  line.syllables.forEach(syl => {
-    gap =
-      lastSylEnd != null && syl.start - lastSylEnd > 10
-        ? `{\\k${(syl.start - lastSylEnd) / 10}}`
-        : "";
-    assLine.push(
-      `${gap}{\\k${getProgressive(syl, options)}${Math.floor(
-        syl.duration / 10
-      )}}${syl.text}`
-    );
+  if(line.syllables) {
+    line.syllables.forEach(syl => {
+      gap =
+        lastSylEnd != null && syl.start - lastSylEnd > 10
+          ? `{\\k${(syl.start - lastSylEnd) / 10}}`
+          : "";
+      assLine.push(
+        `${gap}{\\k${getProgressive(syl, options)}${Math.floor(
+          syl.duration / 10
+        )}}${syl.text}`
+      );
 
-    if (firstStart == null) firstStart = syl.start;
-    lastSylEnd = syl.end;
-  });
+      if (firstStart == null) firstStart = syl.start;
+      lastSylEnd = syl.end;
+    });
+  } else {
+    assLine.push(line.text);
+    firstStart=line.end; // Emulate "fixed text" and use the text style rather than the wipe style
+  }
   const dialogue = clone(ass.defaultDialogue);
 
   dialogue.value.Start = msToAss(startMs);

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -16,6 +16,8 @@ function generateASSLine(line: ISentence, options: IConfig) {
   const assLine = [];
   let startMs = line.start;
   const stopMs = line.end;
+  let display = options.display ?? 1000;
+  let remove = options.remove ?? 100;
   let firstStart = null;
   let lastSylEnd = null;
   let gap = null;
@@ -40,14 +42,19 @@ function generateASSLine(line: ISentence, options: IConfig) {
   }
   const dialogue = clone(ass.defaultDialogue);
 
-  dialogue.value.Start = msToAss(startMs);
-  dialogue.value.End = msToAss(stopMs);
+  // Comment starts exactly with syllables to allow for retiming
+  dialogue.value.Start = msToAss(firstStart);
+  dialogue.value.End = msToAss(remove == -1 ? stopMs : lastSylEnd + remove);
   dialogue.value.Style = line.styleName;
 
   const comment: IDialogueKV<"Comment"> = {
     key: "Comment",
     value: { ...dialogue.value, Text: assLine.join(""), Effect: "karaoke" },
   };
+
+  // Reset start time to actual display for the dialogue lines
+  if(display != -1) startMs = firstStart - display;
+  dialogue.value.Start = msToAss(startMs);
 
   // Horizontal offset only makes sense when there is a set number of pixels to center across
   // TODO: position = true, cdg = false, line.alignment = 0 (pull from style), style.alignment != 8 - style object currently not included in parameters

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -27,7 +27,7 @@ function generateASSLine(line: ISentence, options: IConfig) {
     assLine.push(
       `${gap}{\\k${getProgressive(syl, options)}${Math.floor(
         syl.duration / 10
-      )}${syl.text}}`
+      )}}${syl.text}`
     );
 
     if (firstStart == null) firstStart = syl.start;
@@ -49,9 +49,9 @@ function generateASSLine(line: ISentence, options: IConfig) {
   const pos = options.position ? `\\pos(${hOffset},${line.vpos})` : "";
 
   // TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
-  dialogue.value.Text = `\\an${line.alignment}${pos}\\k${
+  dialogue.value.Text = `{\\an${line.alignment}${pos}\\k${
     (firstStart - startMs) / 10
-  }${ass.dialogueScript}${assLine.join("")}`;
+  }${options.dialogueScript}}${assLine.join("")}`;
   dialogue.value.Effect = "fx";
 
   return {
@@ -105,12 +105,16 @@ export function convertToASS(time: string, options: IConfig) {
       : [{ ...ass.defaultStyle }]
   );
 
+  if (! ('dialogueScript' in options)) {
+    options.dialogueScript = ass.dialogueScript;
+}
+
   comments.push({
     key: "Comment",
     value: {
       ...ass.defaultDialogue.value,
       Effect: ass.scriptFX,
-      Text: ass.scriptFX,
+      Text: ass.script,
     },
   });
   for (const line of kara.track) {

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -61,10 +61,10 @@ function generateASSLine(line: ISentence, options: IConfig) {
 	const hOffset = options.cdg || [0,8].includes(line.alignment) ? line.hpos : 0;
 	const pos = options.position ? `\\pos(${hOffset},${line.vpos})` : "";
 	// TODO: calculate rotation origin if not left-aligned to match KBS?
-	const rot = options.position && line.rotation != 0 ? `\\frz${line.rotation}` : '';
+	const rot = options.position && line.rotation != 0 ? `\\frz${line.rotation}` : "";
 
 	// TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
-	dialogue.value.Text = `{${line.alignment == 0 ? '' : `\\an${line.alignment}`}${pos}${rot}\\k${
+	dialogue.value.Text = `{${line.alignment == 0 ? "" : `\\an${line.alignment}`}${pos}${rot}\\k${
 		(firstStart - startMs) / 10
 	}${options.dialogueScript}}${assLine.join("")}`;
 	dialogue.value.Effect = "fx";
@@ -83,11 +83,11 @@ function escapeAss(text: string, first: boolean = false) {
 	// {} must be escaped to avoid it being interpreted as a tag
 	// 0x200B is a zero-width space. There is nothing like \\ to insert a
 	//   literal \, so this is the best we can do to get a literal \n, \h, \N
-	text = text.replace(/{~}/g, '/')
-		.replace(/[{}]/g, '\\$&')
+	text = text.replace(/{~}/g, "/")
+		.replace(/[{}]/g, "\\$&")
 		.replace(/\\([nhN])/g, `\\${String.fromCharCode(0x200B)}$1`);
 	if(first) {
-		text = text.replace(/^ /, '\\h');
+		text = text.replace(/^ /, "\\h");
 	}
 	return text;
 }
@@ -131,7 +131,7 @@ export function convertToASS(time: string, options: IConfig) {
 		: [{ ...ass.defaultStyle }]
 	);
 
-	if (! ('dialogueScript' in options)) {
+	if (! ("dialogueScript" in options)) {
 		options.dialogueScript = ass.dialogueScript;
 	}
 

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -25,16 +25,16 @@ function generateASSLine(line: ISentence, options: IConfig) {
 		line.syllables.forEach(syl => {
 			gap =
 				lastSylEnd != null && syl.start - lastSylEnd > 10
-				? `{\\k${(syl.start - lastSylEnd) / 10}}`
-				: "";
+					? `{\\k${(syl.start - lastSylEnd) / 10}}`
+					: "";
 			assLine.push(
 				`${gap}{\\k${getProgressive(syl, options)}${Math.floor(
 					syl.duration / 10
 				)}}${escapeAss(syl.text, firstStart == null)}`
 			);
 
-				if (firstStart == null) firstStart = syl.start;
-				lastSylEnd = syl.end;
+			if (firstStart == null) firstStart = syl.start;
+			lastSylEnd = syl.end;
 		});
 	} else {
 		assLine.push(escapeAss(line.text, true));
@@ -127,8 +127,8 @@ export function convertToASS(time: string, options: IConfig) {
 	const styles = clone(ass.styles);
 	styles.body = styles.body.concat(
 		kbp.styles.length > 0
-		? kbp.styles.map(style => getStyleAss(style))
-		: [{ ...ass.defaultStyle }]
+			? kbp.styles.map(style => getStyleAss(style))
+			: [{ ...ass.defaultStyle }]
 	);
 
 	if (! ("dialogueScript" in options)) {

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -1,78 +1,78 @@
 import { clone, msToAss } from "./utils";
 import KBPParser from "./kbp";
 import stringify from "./assStringify";
-import type{
-  IStyle,
-  IConfig,
-  ISentence,
-  ISyllable,
-  IDialogueKV,
-  IStyleKV,
-  IEvents,
+import type {
+	IStyle,
+	IConfig,
+	ISentence,
+	ISyllable,
+	IDialogueKV,
+	IStyleKV,
+	IEvents,
 } from "./types";
 import * as ass from "./assTemplate";
 
 function generateASSLine(line: ISentence, options: IConfig) {
-  const assLine = [];
-  let startMs = line.start;
-  const stopMs = line.end;
-  let display = options.display ?? 1000;
-  let remove = options.remove ?? 100;
-  let firstStart = null;
-  let lastSylEnd = null;
-  let gap = null;
-  if(line.syllables) {
-    line.syllables.forEach(syl => {
-      gap =
-        lastSylEnd != null && syl.start - lastSylEnd > 10
-          ? `{\\k${(syl.start - lastSylEnd) / 10}}`
-          : "";
-      assLine.push(
-        `${gap}{\\k${getProgressive(syl, options)}${Math.floor(
-          syl.duration / 10
-        )}}${escapeAss(syl.text, firstStart == null)}`
-      );
+	const assLine = [];
+	let startMs = line.start;
+	const stopMs = line.end;
+	let display = options.display ?? 1000;
+	let remove = options.remove ?? 100;
+	let firstStart = null;
+	let lastSylEnd = null;
+	let gap = null;
+	if(line.syllables) {
+		line.syllables.forEach(syl => {
+			gap =
+				lastSylEnd != null && syl.start - lastSylEnd > 10
+				? `{\\k${(syl.start - lastSylEnd) / 10}}`
+				: "";
+			assLine.push(
+				`${gap}{\\k${getProgressive(syl, options)}${Math.floor(
+					syl.duration / 10
+				)}}${escapeAss(syl.text, firstStart == null)}`
+			);
 
-      if (firstStart == null) firstStart = syl.start;
-      lastSylEnd = syl.end;
-    });
-  } else {
-    assLine.push(escapeAss(line.text, true));
-    firstStart=line.end; // Emulate "fixed text" and use the text style rather than the wipe style
-  }
-  const dialogue = clone(ass.defaultDialogue);
+				if (firstStart == null) firstStart = syl.start;
+				lastSylEnd = syl.end;
+		});
+	} else {
+		assLine.push(escapeAss(line.text, true));
+		firstStart=line.end; // Emulate "fixed text" and use the text style rather than the wipe style
+	}
+	const dialogue = clone(ass.defaultDialogue);
 
-  // Comment starts exactly with syllables to allow for retiming
-  dialogue.value.Start = msToAss(firstStart);
-  dialogue.value.End = msToAss(remove == -1 ? stopMs : lastSylEnd + remove);
-  dialogue.value.Style = line.styleName;
+	// Comment starts exactly with syllables to allow for retiming
+	dialogue.value.Start = msToAss(firstStart);
+	dialogue.value.End = msToAss(remove == -1 ? stopMs : lastSylEnd + remove);
+	dialogue.value.Style = line.styleName;
 
-  const comment: IDialogueKV<"Comment"> = {
-    key: "Comment",
-    value: { ...dialogue.value, Text: assLine.join(""), Effect: "karaoke" },
-  };
+	const comment: IDialogueKV<"Comment"> = {
+		key: "Comment",
+		value: { ...dialogue.value, Text: assLine.join(""), Effect: "karaoke" },
+	};
 
-  // Reset start time to actual display for the dialogue lines
-  if(display != -1) startMs = firstStart - display;
-  dialogue.value.Start = msToAss(startMs);
+	// Reset start time to actual display for the dialogue lines
+	if(display != -1) startMs = firstStart - display;
+	dialogue.value.Start = msToAss(startMs);
 
-  // Horizontal offset only makes sense when there is a set number of pixels to center across
-  // TODO: position = true, cdg = false, line.alignment = 0 (pull from style), style.alignment != 8 - style object currently not included in parameters
-  const hOffset = options.cdg || [0,8].includes(line.alignment) ? line.hpos : 0;
-  const pos = options.position ? `\\pos(${hOffset},${line.vpos})` : "";
+	// Horizontal offset only makes sense when there is a set number of pixels to center across
+	// TODO: position = true, cdg = false, line.alignment = 0 (pull from style), style.alignment != 8 - style object currently not included in parameters
+	const hOffset = options.cdg || [0,8].includes(line.alignment) ? line.hpos : 0;
+	const pos = options.position ? `\\pos(${hOffset},${line.vpos})` : "";
 	// TODO: calculate rotation origin if not left-aligned to match KBS?
 	const rot = options.position && line.rotation != 0 ? `\\frz${line.rotation}` : '';
 
-  // TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
-  dialogue.value.Text = `{${line.alignment == 0 ? '' : `\\an${line.alignment}`}${pos}${rot}\\k${
-    (firstStart - startMs) / 10
-  }${options.dialogueScript}}${assLine.join("")}`;
-  dialogue.value.Effect = "fx";
+	// TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
+	dialogue.value.Text = `{${line.alignment == 0 ? '' : `\\an${line.alignment}`}${pos}${rot}\\k${
+		(firstStart - startMs) / 10
+	}${options.dialogueScript}}${assLine.join("")}`;
+	dialogue.value.Effect = "fx";
 
-  return {
-    dialogue,
-    comment,
-  };
+	return {
+		dialogue,
+		comment,
+	};
 }
 
 // Technically this should be two separate functions because {~} is a KBSism
@@ -84,98 +84,92 @@ function escapeAss(text: string, first: boolean = false) {
 	// 0x200B is a zero-width space. There is nothing like \\ to insert a
 	//   literal \, so this is the best we can do to get a literal \n, \h, \N
 	text = text.replace(/{~}/g, '/')
-	           .replace(/[{}]/g, '\\$&')
-		       .replace(/\\([nhN])/g, `\\${String.fromCharCode(0x200B)}$1`);
-    if(first) {
-        text = text.replace(/^ /, '\\h');
-    }
-    return text;
+		.replace(/[{}]/g, '\\$&')
+		.replace(/\\([nhN])/g, `\\${String.fromCharCode(0x200B)}$1`);
+	if(first) {
+		text = text.replace(/^ /, '\\h');
+	}
+	return text;
 }
 
 function getProgressive(syl: ISyllable, options: IConfig) {
-  // When duration exceeds the threshold, progressive wiping may be possible
-  if (
-    Math.floor(syl.duration / 10) >
-    Math.floor(options["minimum-progression-duration"] / 10)
-  ) {
-    // If option is set to use wiping setting from the kbp file, do so, otherwise set unconditionally
-    return options.wipe && !syl.wipeProgressive ? "" : "f";
-    // If duration does not exceed the threshold, progressive wiping cannot be
-    // used, regardless of kbp setting
-  } else {
-    return "";
-  }
+	// When duration exceeds the threshold, progressive wiping may be possible
+	if (
+		Math.floor(syl.duration / 10) >
+		Math.floor(options["minimum-progression-duration"] / 10)
+	) {
+		// If option is set to use wiping setting from the kbp file, do so, otherwise set unconditionally
+		return options.wipe && !syl.wipeProgressive ? "" : "f";
+		// If duration does not exceed the threshold, progressive wiping cannot be
+		// used, regardless of kbp setting
+	} else {
+		return "";
+	}
 }
 
-// function sortStartTime<T>(a: IDialogueKV<T>, b: IDialogueKV<T>) {
-//   if (a.value.Start < b.value.Start) return -1;
-//   if (a.value.Start > b.value.Start) return 1;
-//   return 0;
-// }
-
 function getStyleAss(style: IStyle): IStyleKV {
-  return {
-    key: "Style",
-    value: {
-      ...ass.defaultStyle.value,
-      ...style,
-    },
-  };
+	return {
+		key: "Style",
+		value: {
+			...ass.defaultStyle.value,
+			...style,
+		},
+	};
 }
 
 /** Convert KBP data (txt) to ASS */
 export function convertToASS(time: string, options: IConfig) {
-  const kbp = new KBPParser(options);
-  const kara = kbp.parse(time);
-  const dialogues: IDialogueKV<"Dialogue">[] = [];
-  const comments: IDialogueKV<"Comment">[] = [];
+	const kbp = new KBPParser(options);
+	const kara = kbp.parse(time);
+	const dialogues: IDialogueKV<"Dialogue">[] = [];
+	const comments: IDialogueKV<"Comment">[] = [];
 
-  const styles = clone(ass.styles);
-  styles.body = styles.body.concat(
-    kbp.styles.length > 0
-      ? kbp.styles.map(style => getStyleAss(style))
-      : [{ ...ass.defaultStyle }]
-  );
+	const styles = clone(ass.styles);
+	styles.body = styles.body.concat(
+		kbp.styles.length > 0
+		? kbp.styles.map(style => getStyleAss(style))
+		: [{ ...ass.defaultStyle }]
+	);
 
-  if (! ('dialogueScript' in options)) {
-    options.dialogueScript = ass.dialogueScript;
-}
+	if (! ('dialogueScript' in options)) {
+		options.dialogueScript = ass.dialogueScript;
+	}
 
-  comments.push({
-    key: "Comment",
-    value: {
-      ...ass.defaultDialogue.value,
-      Effect: ass.scriptFX,
-      Text: ass.script,
-    },
-  });
-  for (const line of kara.track) {
-    const ASSLines = generateASSLine(line, options);
-    comments.push(clone(ASSLines.comment));
-    dialogues.push(clone(ASSLines.dialogue));
-  }
-  // Function seems to be unnecessary. And it removes functionality (implicit
-  // layering based on line/page order)
-  //comments.sort(sortStartTime);
-  //dialogues.sort(sortStartTime);
-  const events: IEvents = {
-    section: "Events",
-    body: [...ass.events.body, ...comments, ...dialogues],
-  };
+	comments.push({
+		key: "Comment",
+		value: {
+			...ass.defaultDialogue.value,
+			Effect: ass.scriptFX,
+			Text: ass.script,
+		},
+	});
+	for (const line of kara.track) {
+		const ASSLines = generateASSLine(line, options);
+		comments.push(clone(ASSLines.comment));
+		dialogues.push(clone(ASSLines.dialogue));
+	}
+	// Function seems to be unnecessary. And it removes functionality (implicit
+	// layering based on line/page order)
+	//comments.sort(sortStartTime);
+	//dialogues.sort(sortStartTime);
+	const events: IEvents = {
+		section: "Events",
+		body: [...ass.events.body, ...comments, ...dialogues],
+	};
 
-  const header = clone(ass.scriptInfo);
-  if (options.cdg) {
-    if (options.border) {
-      header.body.push(
-        { key: "PlayResX", value: options.width ?? 300 },
-        { key: "PlayResY", value: 216 }
-      );
-    } else {
-      header.body.push(
-        { key: "PlayResX", value: options.width ?? 288 },
-        { key: "PlayResY", value: 192 }
-      );
-    }
-  }
-  return stringify([header, styles, events]);
+	const header = clone(ass.scriptInfo);
+	if (options.cdg) {
+		if (options.border) {
+			header.body.push(
+				{ key: "PlayResX", value: options.width ?? 300 },
+				{ key: "PlayResY", value: 216 }
+			);
+		} else {
+			header.body.push(
+				{ key: "PlayResX", value: options.width ?? 288 },
+				{ key: "PlayResY", value: 192 }
+			);
+		}
+	}
+	return stringify([header, styles, events]);
 }

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -28,14 +28,14 @@ function generateASSLine(line: ISentence, options: IConfig) {
       assLine.push(
         `${gap}{\\k${getProgressive(syl, options)}${Math.floor(
           syl.duration / 10
-        )}}${escapeAss(syl.text)}`
+        )}}${escapeAss(syl.text, firstStart == null)}`
       );
 
       if (firstStart == null) firstStart = syl.start;
       lastSylEnd = syl.end;
     });
   } else {
-    assLine.push(escapeAss(line.text));
+    assLine.push(escapeAss(line.text, true));
     firstStart=line.end; // Emulate "fixed text" and use the text style rather than the wipe style
   }
   const dialogue = clone(ass.defaultDialogue);
@@ -70,14 +70,18 @@ function generateASSLine(line: ISentence, options: IConfig) {
 // Technically this should be two separate functions because {~} is a KBSism
 // and escaping of {} and handling of literal \n, \N, \h are .ass things, but
 // it was simpler just to make one.
-function escapeAss(text: string) {
+function escapeAss(text: string, first: boolean = false) {
 	// Literal / is encoded in .kbp as {~} since / is the end of syllable character
 	// {} must be escaped to avoid it being interpreted as a tag
 	// 0x200B is a zero-width space. There is nothing like \\ to insert a
 	//   literal \, so this is the best we can do to get a literal \n, \h, \N
-	return text.replace(/{~}/g, '/')
+	text = text.replace(/{~}/g, '/')
 	           .replace(/[{}]/g, '\\$&')
-		   .replace(/\\([nhN])/g, `\\${String.fromCharCode(0x200B)}$1`);
+		       .replace(/\\([nhN])/g, `\\${String.fromCharCode(0x200B)}$1`);
+    if(first) {
+        text = text.replace(/^ /, '\\h');
+    }
+    return text;
 }
 
 function getProgressive(syl: ISyllable, options: IConfig) {

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -82,11 +82,11 @@ function getProgressive(syl: ISyllable, options: IConfig) {
   }
 }
 
-function sortStartTime<T>(a: IDialogueKV<T>, b: IDialogueKV<T>) {
-  if (a.value.Start < b.value.Start) return -1;
-  if (a.value.Start > b.value.Start) return 1;
-  return 0;
-}
+// function sortStartTime<T>(a: IDialogueKV<T>, b: IDialogueKV<T>) {
+//   if (a.value.Start < b.value.Start) return -1;
+//   if (a.value.Start > b.value.Start) return 1;
+//   return 0;
+// }
 
 function getStyleAss(style: IStyle): IStyleKV {
   return {
@@ -129,8 +129,10 @@ export function convertToASS(time: string, options: IConfig) {
     comments.push(clone(ASSLines.comment));
     dialogues.push(clone(ASSLines.dialogue));
   }
-  comments.sort(sortStartTime);
-  dialogues.sort(sortStartTime);
+  // Function seems to be unnecessary. And it removes functionality (implicit
+  // layering based on line/page order)
+  //comments.sort(sortStartTime);
+  //dialogues.sort(sortStartTime);
   const events: IEvents = {
     section: "Events",
     body: [...ass.events.body, ...comments, ...dialogues],

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -42,7 +42,7 @@ function generateASSLine(line: ISentence, options: IConfig) {
 
   dialogue.value.Start = msToAss(startMs);
   dialogue.value.End = msToAss(stopMs);
-  dialogue.value.Style = line.currentStyle;
+  dialogue.value.Style = line.styleName;
 
   const comment: IDialogueKV<"Comment"> = {
     key: "Comment",

--- a/src/assStringify.ts
+++ b/src/assStringify.ts
@@ -1,4 +1,4 @@
-/*  
+/*
 
 * Based on: `https://github.com/eush77/ass-stringify` 
 
@@ -12,40 +12,40 @@ import type { IDialogueKV, IFormatKV, IScriptInfo, TSection } from "./types";
 import { pickValues } from "./utils";
 
 const stringifyDescriptor = {
-  comment: (comment: IScriptInfo["body"][0]) => ";" + comment.value,
-  formatSpec: (formatSpec: IFormatKV) =>
-    formatSpec.key + ": " + formatSpec.value.join(", "),
-  properties: (properties: IDialogueKV<string>, format: IFormatKV["value"]) =>
-    properties.key + ": " + pickValues(properties.value, format).join(","),
-  raw: (raw: IDialogueKV<string>) => raw.key + ": " + raw.value,
+	comment: (comment: IScriptInfo["body"][0]) => ";" + comment.value,
+	formatSpec: (formatSpec: IFormatKV) =>
+		formatSpec.key + ": " + formatSpec.value.join(", "),
+	properties: (properties: IDialogueKV<string>, format: IFormatKV["value"]) =>
+		properties.key + ": " + pickValues(properties.value, format).join(","),
+	raw: (raw: IDialogueKV<string>) => raw.key + ": " + raw.value,
 };
 
 function stringifySection(section: TSection) {
-  const head = "[" + section.section + "]";
-  let format = null;
+	const head = "[" + section.section + "]";
+	let format = null;
 
-  const body = section.body
-    .map(descriptor => {
-      const method =
-        descriptor.type == "comment"
-          ? "comment"
-          : descriptor.key == "Format"
-          ? "formatSpec"
-          : format
-          ? "properties"
-          : "raw";
+	const body = section.body
+		.map(descriptor => {
+			const method =
+				descriptor.type == "comment"
+					? "comment"
+					: descriptor.key == "Format"
+						? "formatSpec"
+						: format
+							? "properties"
+							: "raw";
 
-      if (method == "formatSpec") {
-        format = descriptor.value;
-      }
+			if (method == "formatSpec") {
+				format = descriptor.value;
+			}
 
-      return stringifyDescriptor[method](descriptor, format);
-    })
-    .join("\n");
+			return stringifyDescriptor[method](descriptor, format);
+		})
+	.join("\n");
 
-  return body ? head + "\n" + body : head;
+	return body ? head + "\n" + body : head;
 }
 
 export default function stringifyAss(ass: TSection[]) {
-  return ass.map(stringifySection).join("\n\n") + "\n";
+	return ass.map(stringifySection).join("\n\n") + "\n";
 }

--- a/src/assStringify.ts
+++ b/src/assStringify.ts
@@ -1,0 +1,51 @@
+/*  
+
+* Based on: `https://github.com/eush77/ass-stringify` 
+
+* By: `eush77`
+
+* License: `MIT`
+
+*/
+
+import type { IDialogueKV, IFormatKV, IScriptInfo, TSection } from "./types";
+import { pickValues } from "./utils";
+
+const stringifyDescriptor = {
+  comment: (comment: IScriptInfo["body"][0]) => ";" + comment.value,
+  formatSpec: (formatSpec: IFormatKV) =>
+    formatSpec.key + ": " + formatSpec.value.join(", "),
+  properties: (properties: IDialogueKV<string>, format: IFormatKV["value"]) =>
+    properties.key + ": " + pickValues(properties.value, format).join(","),
+  raw: (raw: IDialogueKV<string>) => raw.key + ": " + raw.value,
+};
+
+function stringifySection(section: TSection) {
+  const head = "[" + section.section + "]";
+  let format = null;
+
+  const body = section.body
+    .map(descriptor => {
+      const method =
+        descriptor.type == "comment"
+          ? "comment"
+          : descriptor.key == "Format"
+          ? "formatSpec"
+          : format
+          ? "properties"
+          : "raw";
+
+      if (method == "formatSpec") {
+        format = descriptor.value;
+      }
+
+      return stringifyDescriptor[method](descriptor, format);
+    })
+    .join("\n");
+
+  return body ? head + "\n" + body : head;
+}
+
+export default function stringifyAss(ass: TSection[]) {
+  return ass.map(stringifySection).join("\n\n") + "\n";
+}

--- a/src/assStringify.ts
+++ b/src/assStringify.ts
@@ -41,7 +41,7 @@ function stringifySection(section: TSection) {
 
 			return stringifyDescriptor[method](descriptor, format);
 		})
-	.join("\n");
+		.join("\n");
 
 	return body ? head + "\n" + body : head;
 }

--- a/src/assTemplate.ts
+++ b/src/assTemplate.ts
@@ -1,133 +1,143 @@
-export const scriptInfo = {
-	section: 'Script Info',
+import type {
+	IDialogueKV,
+	IEvents,
+	IScriptInfo,
+	IStyleKV,
+	IStyles,
+  } from "./types";
+  
+  export const scriptInfo: IScriptInfo = {
+	section: "Script Info",
 	body: [
-		{
-			type: 'comment',
-			value: 'Converted using kbp2ass : https://github.com/Aeden-B/kbp2ass'
-		},
-		{
-			key: 'Title',
-			value: ''
-		},
-		{
-			key: 'ScriptType',
-			value: 'v4.00+'
-		},
-		{
-			key: 'WrapStyle',
-			value: 0
-		},
-		{
-			key: 'ScaledBorderAndShadow',
-			value: 'yes'
-		},
-		{
-			key: 'Collisions',
-			value: 'Normal'
-		}
-	]
-};
-
-export const styles = {
-	section: 'V4+ Styles',
+	  {
+		type: "comment",
+		value: "Converted using kbp2ass : https://github.com/Aeden-B/kbp2ass",
+	  },
+	  {
+		key: "Title",
+		value: "",
+	  },
+	  {
+		key: "ScriptType",
+		value: "v4.00+",
+	  },
+	  {
+		key: "WrapStyle",
+		value: 0,
+	  },
+	  {
+		key: "ScaledBorderAndShadow",
+		value: "yes",
+	  },
+	  {
+		key: "Collisions",
+		value: "Normal",
+	  },
+	],
+  };
+  
+  export const styles: IStyles = {
+	section: "V4+ Styles",
 	body: [
-		{
-			key: 'Format',
-			value: [
-				'Name',
-				'Fontname',
-				'Fontsize',
-				'PrimaryColour',
-				'SecondaryColour',
-				'OutlineColour',
-				'BackColour',
-				'Bold',
-				'Italic',
-				'Underline',
-				'StrikeOut',
-				'ScaleX',
-				'ScaleY',
-				'Spacing',
-				'Angle',
-				'BorderStyle',
-				'Outline',
-				'Shadow',
-				'Alignment',
-				'MarginL',
-				'MarginR',
-				'MarginV',
-				'Encoding'
-			]
-		}
-	]
-};
-
-export const defaultStyle = {
-	key: 'Style',
+	  {
+		key: "Format",
+		value: [
+		  "Name",
+		  "Fontname",
+		  "Fontsize",
+		  "PrimaryColour",
+		  "SecondaryColour",
+		  "OutlineColour",
+		  "BackColour",
+		  "Bold",
+		  "Italic",
+		  "Underline",
+		  "StrikeOut",
+		  "ScaleX",
+		  "ScaleY",
+		  "Spacing",
+		  "Angle",
+		  "BorderStyle",
+		  "Outline",
+		  "Shadow",
+		  "Alignment",
+		  "MarginL",
+		  "MarginR",
+		  "MarginV",
+		  "Encoding",
+		],
+	  },
+	],
+  };
+  
+  export const defaultStyle: IStyleKV = {
+	key: "Style",
 	value: {
-		'Name': 'Default',
-		'Fontname': 'Arial',
-		'Fontsize': '24',
-		'PrimaryColour': '&H00FFFFFF',
-		'SecondaryColour': '&H000088EF',
-		'OutlineColour': '&H00000000',
-		'BackColour': '&H00666666',
-		'Bold': '-1',
-		'Italic': '0',
-		'Underline': '0',
-		'StrikeOut': '0',
-		'ScaleX': '100',
-		'ScaleY': '100',
-		'Spacing': '0',
-		'Angle': '0',
-		'BorderStyle': '1',
-		'Outline': '1.5',
-		'Shadow': '0',
-		'Alignment': '8',
-		'MarginL': '0',
-		'MarginR': '0',
-		'MarginV': '20',
-		'Encoding': '1'
-	}
-};
-
-export const events = {
-	section: 'Events',
+	  Name: "Default",
+	  Fontname: "Arial",
+	  Fontsize: 24,
+	  PrimaryColour: "&H00FFFFFF",
+	  SecondaryColour: "&H000088EF",
+	  OutlineColour: "&H00000000",
+	  BackColour: "&H00666666",
+	  Bold: -1,
+	  Italic: 0,
+	  Underline: 0,
+	  StrikeOut: 0,
+	  ScaleX: 100,
+	  ScaleY: 100,
+	  Spacing: 0,
+	  Angle: 0,
+	  BorderStyle: 1,
+	  Outline: 1.5,
+	  Shadow: 0,
+	  Alignment: 8,
+	  MarginL: 0,
+	  MarginR: 0,
+	  MarginV: 20,
+	  Encoding: 1,
+	},
+  };
+  
+  export const events: IEvents = {
+	section: "Events",
 	body: [
-		{
-			key: 'Format',
-			'value': [
-				'Layer',
-				'Start',
-				'End',
-				'Style',
-				'Name',
-				'MarginL',
-				'MarginR',
-				'MarginV',
-				'Effect',
-				'Text'
-			]
-		}
-	]
-};
-
-export const dialogue = {
-	key: 'Dialogue',
+	  {
+		key: "Format",
+		value: [
+		  "Layer",
+		  "Start",
+		  "End",
+		  "Style",
+		  "Name",
+		  "MarginL",
+		  "MarginR",
+		  "MarginV",
+		  "Effect",
+		  "Text",
+		],
+	  },
+	],
+  };
+  
+  export const defaultDialogue: IDialogueKV<"Dialogue"> = {
+	key: "Dialogue",
 	value: {
-		Layer: '1',
-		Start: '0:00:00.00',
-		End: '0:00:00.00',
-		Style: 'Default',
-		Name: '',
-		MarginL: '0',
-		MarginR: '0',
-		MarginV: '0',
-		Effect: '',
-		Text: ''
-	}
-};
-
-export const dialogueScript = '\\fad(300,200)';
-export const scriptFX = 'template pre-line all keeptags';
-export const script = '!retime("line",$start < 900 and -$start or -900,200)!{!$start < 900 and "\\\\k" .. ($start/10) or "\\\\k90"!\\fad(!$start < 900 and $start or 300!,200)}';
+	  Layer: "1",
+	  Start: "0:00:00.00",
+	  End: "0:00:00.00",
+	  Style: "Default",
+	  Name: "",
+	  MarginL: "0",
+	  MarginR: "0",
+	  MarginV: "0",
+	  Effect: "",
+	  Text: "",
+	},
+  };
+  
+  export const dialogueScript = "\\fad(300,200)}";
+  export const scriptFX = "template pre-line all keeptags";
+  export const script =
+	'!retime("line",$start < 900 and -$start or -900,200)!{!$start < 900 and "\\\\k" .. ($start/10) or "\\\\k90"!\\fad(!$start < 900 and $start or 300!,200)}';
+  

--- a/src/assTemplate.ts
+++ b/src/assTemplate.ts
@@ -128,6 +128,6 @@ export const dialogue = {
 	}
 };
 
-export const dialogueScript = '\\fad(300,200)}';
+export const dialogueScript = '\\fad(50,50)}';
 export const scriptFX = 'template pre-line all keeptags';
 export const script = '!retime("line",$start < 900 and -$start or -900,200)!{!$start < 900 and "\\\\k" .. ($start/10) or "\\\\k90"!\\fad(!$start < 900 and $start or 300!,200)}';

--- a/src/assTemplate.ts
+++ b/src/assTemplate.ts
@@ -4,140 +4,140 @@ import type {
 	IScriptInfo,
 	IStyleKV,
 	IStyles,
-  } from "./types";
-  
-  export const scriptInfo: IScriptInfo = {
+} from "./types";
+
+export const scriptInfo: IScriptInfo = {
 	section: "Script Info",
 	body: [
-	  {
-		type: "comment",
-		value: "Converted using kbp2ass : https://github.com/Aeden-B/kbp2ass",
-	  },
-	  {
-		key: "Title",
-		value: "",
-	  },
-	  {
-		key: "ScriptType",
-		value: "v4.00+",
-	  },
-	  {
-		key: "WrapStyle",
-		value: 0,
-	  },
-	  {
-		key: "ScaledBorderAndShadow",
-		value: "yes",
-	  },
-	  {
-		key: "Collisions",
-		value: "Normal",
-	  },
+		{
+			type: "comment",
+			value: "Converted using kbp2ass : https://github.com/Aeden-B/kbp2ass",
+		},
+		{
+			key: "Title",
+			value: "",
+		},
+		{
+			key: "ScriptType",
+			value: "v4.00+",
+		},
+		{
+			key: "WrapStyle",
+			value: 0,
+		},
+		{
+			key: "ScaledBorderAndShadow",
+			value: "yes",
+		},
+		{
+			key: "Collisions",
+			value: "Normal",
+		},
 	],
-  };
-  
-  export const styles: IStyles = {
+};
+
+export const styles: IStyles = {
 	section: "V4+ Styles",
 	body: [
-	  {
-		key: "Format",
-		value: [
-		  "Name",
-		  "Fontname",
-		  "Fontsize",
-		  "PrimaryColour",
-		  "SecondaryColour",
-		  "OutlineColour",
-		  "BackColour",
-		  "Bold",
-		  "Italic",
-		  "Underline",
-		  "StrikeOut",
-		  "ScaleX",
-		  "ScaleY",
-		  "Spacing",
-		  "Angle",
-		  "BorderStyle",
-		  "Outline",
-		  "Shadow",
-		  "Alignment",
-		  "MarginL",
-		  "MarginR",
-		  "MarginV",
-		  "Encoding",
-		],
-	  },
+		{
+			key: "Format",
+			value: [
+				"Name",
+				"Fontname",
+				"Fontsize",
+				"PrimaryColour",
+				"SecondaryColour",
+				"OutlineColour",
+				"BackColour",
+				"Bold",
+				"Italic",
+				"Underline",
+				"StrikeOut",
+				"ScaleX",
+				"ScaleY",
+				"Spacing",
+				"Angle",
+				"BorderStyle",
+				"Outline",
+				"Shadow",
+				"Alignment",
+				"MarginL",
+				"MarginR",
+				"MarginV",
+				"Encoding",
+			],
+		},
 	],
-  };
-  
-  export const defaultStyle: IStyleKV = {
+};
+
+export const defaultStyle: IStyleKV = {
 	key: "Style",
 	value: {
-	  Name: "Default",
-	  Fontname: "Arial",
-	  Fontsize: "24",
-	  PrimaryColour: "&H00FFFFFF",
-	  SecondaryColour: "&H000088EF",
-	  OutlineColour: "&H00000000",
-	  BackColour: "&H00666666",
-	  Bold: -1,
-	  Italic: 0,
-	  Underline: 0,
-	  StrikeOut: 0,
-	  ScaleX: 100,
-	  ScaleY: 100,
-	  Spacing: 0,
-	  Angle: 0,
-	  BorderStyle: 1,
-	  Outline: 1.5,
-	  Shadow: 0,
-	  Alignment: 8,
-	  MarginL: 0,
-	  MarginR: 0,
-	  MarginV: 20,
-	  Encoding: 1,
+		Name: "Default",
+		Fontname: "Arial",
+		Fontsize: "24",
+		PrimaryColour: "&H00FFFFFF",
+		SecondaryColour: "&H000088EF",
+		OutlineColour: "&H00000000",
+		BackColour: "&H00666666",
+		Bold: -1,
+		Italic: 0,
+		Underline: 0,
+		StrikeOut: 0,
+		ScaleX: 100,
+		ScaleY: 100,
+		Spacing: 0,
+		Angle: 0,
+		BorderStyle: 1,
+		Outline: 1.5,
+		Shadow: 0,
+		Alignment: 8,
+		MarginL: 0,
+		MarginR: 0,
+		MarginV: 20,
+		Encoding: 1,
 	},
-  };
-  
-  export const events: IEvents = {
+};
+
+export const events: IEvents = {
 	section: "Events",
 	body: [
-	  {
-		key: "Format",
-		value: [
-		  "Layer",
-		  "Start",
-		  "End",
-		  "Style",
-		  "Name",
-		  "MarginL",
-		  "MarginR",
-		  "MarginV",
-		  "Effect",
-		  "Text",
-		],
-	  },
+		{
+			key: "Format",
+			value: [
+				"Layer",
+				"Start",
+				"End",
+				"Style",
+				"Name",
+				"MarginL",
+				"MarginR",
+				"MarginV",
+				"Effect",
+				"Text",
+			],
+		},
 	],
-  };
-  
-  export const defaultDialogue: IDialogueKV<"Dialogue"> = {
+};
+
+export const defaultDialogue: IDialogueKV<"Dialogue"> = {
 	key: "Dialogue",
 	value: {
-	  Layer: "1",
-	  Start: "0:00:00.00",
-	  End: "0:00:00.00",
-	  Style: "Default",
-	  Name: "",
-	  MarginL: "0",
-	  MarginR: "0",
-	  MarginV: "0",
-	  Effect: "",
-	  Text: "",
+		Layer: "1",
+		Start: "0:00:00.00",
+		End: "0:00:00.00",
+		Style: "Default",
+		Name: "",
+		MarginL: "0",
+		MarginR: "0",
+		MarginV: "0",
+		Effect: "",
+		Text: "",
 	},
-  };
-  
-  export const dialogueScript = "\\fad(300,200)";
-  export const scriptFX = "template pre-line all keeptags";
-  export const script =
+};
+
+export const dialogueScript = "\\fad(300,200)";
+export const scriptFX = "template pre-line all keeptags";
+export const script =
 	'!retime("line",$start < 900 and -$start or -900,200)!{!$start < 900 and "\\\\k" .. ($start/10) or "\\\\k90"!\\fad(!$start < 900 and $start or 300!,200)}';
-  
+

--- a/src/assTemplate.ts
+++ b/src/assTemplate.ts
@@ -136,7 +136,7 @@ import type {
 	},
   };
   
-  export const dialogueScript = "\\fad(300,200)}";
+  export const dialogueScript = "\\fad(300,200)";
   export const scriptFX = "template pre-line all keeptags";
   export const script =
 	'!retime("line",$start < 900 and -$start or -900,200)!{!$start < 900 and "\\\\k" .. ($start/10) or "\\\\k90"!\\fad(!$start < 900 and $start or 300!,200)}';

--- a/src/assTemplate.ts
+++ b/src/assTemplate.ts
@@ -128,6 +128,6 @@ export const dialogue = {
 	}
 };
 
-export const dialogueScript = '\\fad(50,50)}';
+export const dialogueScript = '\\fad(300,200)';
 export const scriptFX = 'template pre-line all keeptags';
 export const script = '!retime("line",$start < 900 and -$start or -900,200)!{!$start < 900 and "\\\\k" .. ($start/10) or "\\\\k90"!\\fad(!$start < 900 and $start or 300!,200)}';

--- a/src/assTemplate.ts
+++ b/src/assTemplate.ts
@@ -75,7 +75,7 @@ import type {
 	value: {
 	  Name: "Default",
 	  Fontname: "Arial",
-	  Fontsize: 24,
+	  Fontsize: "24",
 	  PrimaryColour: "&H00FFFFFF",
 	  SecondaryColour: "&H000088EF",
 	  OutlineColour: "&H00000000",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,16 @@ function generateASSLine(line: any, options: ConverterConfig) {
 	let startMs = line.start;
 	const stopMs = line.end;
 	let firstStart = null;
-  let lastSylEnd = null;
-  let gap = null;
+	let lastSylEnd = null;
+	let gap = null;
 	line.syllables.forEach((syl: any) => {
-    if(lastSylEnd != null && syl.start - lastSylEnd > 10) {
-      gap = '{\\k' + ((syl.start - lastSylEnd) / 10) + '}';
-    } else {
-      gap = ''
-    }
+		if(lastSylEnd != null && syl.start - lastSylEnd > 10) {
+			gap = '{\\k' + ((syl.start - lastSylEnd) / 10) + '}';
+		} else {
+			gap = ''
+		}
 		ASSLine.push(
-      gap
+			gap
 			+ '{\\k'
 			+ getProgressive(syl, options)
 			+ Math.floor(syl.duration / 10)
@@ -29,7 +29,7 @@ function generateASSLine(line: any, options: ConverterConfig) {
 			+ syl.text
 		)
 		if (firstStart == null) firstStart=syl.start
-    lastSylEnd = syl.end;
+		lastSylEnd = syl.end;
 		});
 	const dialogue = clone(ass.dialogue);
 	const comment = clone(ass.dialogue);
@@ -37,10 +37,10 @@ function generateASSLine(line: any, options: ConverterConfig) {
 	comment.value.Start = msToAss(startMs);
 	dialogue.value.End = msToAss(stopMs);
 	comment.value.End = msToAss(stopMs);
-  // Horizontal offset only makes sense when there is a set number of pixels to center across
-  const hOffset = (options.cdg || line.alignment != 8) ? line.hpos : 0;
-  const pos = options.position ? '\\pos(' + hOffset + ',' + line.vpos + ')' : '';
-  // TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
+	// Horizontal offset only makes sense when there is a set number of pixels to center across
+	const hOffset = (options.cdg || line.alignment != 8) ? line.hpos : 0;
+	const pos = options.position ? '\\pos(' + hOffset + ',' + line.vpos + ')' : '';
+	// TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
 	dialogue.value.Text = '{\\an'+line.alignment+pos+'\\k' + ((firstStart - startMs) / 10) + ass.dialogueScript + ASSLine.join('');
 	dialogue.value.Effect = 'fx';
 	dialogue.value.Style = line.currentStyle;
@@ -55,19 +55,19 @@ function generateASSLine(line: any, options: ConverterConfig) {
 }
 
 function getProgressive(syl: any, options: ConverterConfig) {
-  // When duration exceeds the threshold, progressive wiping may be possible
+	// When duration exceeds the threshold, progressive wiping may be possible
 	if (Math.floor(syl.duration / 10) > Math.floor(options['minimum-progression-duration'] / 10)) {
-    // If option is set to use wiping setting from the kbp file, do so, otherwise set unconditionally
-    if (options.wipe) {
-      return syl.wipeProgressive ? 'f' : '';
-    } else {
-      return 'f';
-    }
-    // If duration does not exceed the threshold, progressive wiping cannot be
-    // used, regardless of kbp setting
-  } else {
-    return '';
-  }
+		// If option is set to use wiping setting from the kbp file, do so, otherwise set unconditionally
+		if (options.wipe) {
+			return syl.wipeProgressive ? 'f' : '';
+		} else {
+			return 'f';
+		}
+		// If duration does not exceed the threshold, progressive wiping cannot be
+		// used, regardless of kbp setting
+	} else {
+		return '';
+	}
 }
 
 function sortStartTime(a: any, b: any) {
@@ -162,7 +162,7 @@ async function mainCLI() {
 
 						Convert file from KBS project format (.kbp) to SubStation Alpha subtitle (.ass)
 
-						infile:	input file in .kbp format (stdin if not specified)
+						infile:  input file in .kbp format (stdin if not specified)
 						outfile: output file in .ass format (stdout if not specified)
 
 						For compatibility with older releases, minimum-progression-duration can be specified as a positional parameter instead of an option (if both are specified, the positional wins). If your output file name happens to be a number, use -- at some point before the second positional parameter to disable this functionality.

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,12 @@ export function convertToASS(time: string, options: ConverterConfig): string {
 	const comments = [];
 
 	const styles = clone(ass.styles);
-	styles.body = styles.body.concat(kbp.styles.length > 0 ? kbp.styles.map(style => getStyleAss(style)) :	[ass.defaultStyle]);
+	styles.body = styles.body.concat(kbp.styles.length > 0 ?
+		kbp.styles
+			.filter(style => style !== undefined)
+			.map(style => getStyleAss(style)) :	
+		[ass.defaultStyle]
+	);
 	const script = clone(ass.dialogue);
 	script.value.Effect = ass.scriptFX;
 	script.value.Text = ass.script;
@@ -158,16 +163,16 @@ async function mainCLI() {
 		})
 		// Unable to use .positional handling because yargs inexplicably treats "$0 foo bar" differently from "$0 -- foo bar"
 		.usage(`$0 [options] [--] [infile [outfile]]
-						$0 [options] infile minimum-progression-duration [--] [outfile] 
+		        $0 [options] infile minimum-progression-duration [--] [outfile] 
 
-						Convert file from KBS project format (.kbp) to SubStation Alpha subtitle (.ass)
+		        Convert file from KBS project format (.kbp) to SubStation Alpha subtitle (.ass)
 
-						infile:  input file in .kbp format (stdin if not specified)
-						outfile: output file in .ass format (stdout if not specified)
+		        infile:  input file in .kbp format (stdin if not specified)
+		        outfile: output file in .ass format (stdout if not specified)
 
-						For compatibility with older releases, minimum-progression-duration can be specified as a positional parameter instead of an option (if both are specified, the positional wins). If your output file name happens to be a number, use -- at some point before the second positional parameter to disable this functionality.
+		        For compatibility with older releases, minimum-progression-duration can be specified as a positional parameter instead of an option (if both are specified, the positional wins). If your output file name happens to be a number, use -- at some point before the second positional parameter to disable this functionality.
 
-						Disable any boolean option with --no-[option]`)
+		        Disable any boolean option with --no-[option]`)
 		// Used for compatibility with old syntax allowing minimum-progression-duration as a positional
 		// .positional only includes items before --, so this is how to tell if the second argument is before -- or not
 		.command('* [compat1] [compat2]', false, function(yargs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ async function mainCLI() {
 			},
 			'full-mode': {
 				alias: 'f',
-				description: 'Enable processing of all positional and style information in the KBS project file (-w, -p, -b, -c). To unset any particular options use --no-{option}. For example, to run in full mode but with no border set, use "-f --no-b" or "--full-mode --no-border".',
+				description: 'Enable processing of all positional and style information in the KBS project file (-w, -p, -b, -c, -t). To unset any particular options use --no-{option}. For example, to run in full mode but with no border set, use "-f --no-b" or "--full-mode --no-border".',
 				type: 'boolean',
 				requiresArg: false,
 				nargs: 0
@@ -257,6 +257,13 @@ async function mainCLI() {
 				type: 'string',
 				requiresArg: true,
 				nargs: 1
+			},
+			'transparency': {
+				alias: 't',
+				description: 'When using palette color 0, always treat it as transparent. This more closely models the behavior KBS uses when generating a CDG, because drawing in the background color XORs with 0, thus not updating the screen. This setting will only be noticeable if you overlap text or render the .ass against a different background color than is defined in the kbp file (or overlay an image/video).',
+				type: 'boolean',
+				requiresArg: false,
+				nargs: 0
 			}
 		})
 		.strictOptions()
@@ -282,6 +289,7 @@ async function mainCLI() {
 					position: true,
 					border: true,
 					cdg: true,
+          transparency: true,
 					...argv
 				}
 			}
@@ -304,7 +312,7 @@ async function mainCLI() {
 				delete argv.compat1;
 			}
 			// "default" functionality from yargs cannot be used because it doesn't show whether a user set the value or the default set it
-			const default_opts = ['wipe', 'position', 'border', 'cdg', 'full-mode'];
+			const default_opts = ['wipe', 'position', 'border', 'cdg', 'full-mode', 'transparency'];
 			for(let x in default_opts)
 			{
 				const opt = default_opts[x];

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,17 @@ import { readFileSync } from "node:fs";
 import { convertToASS } from "./ass";
 
 function fadeToDialogueScript(fade: string) {
-	let [fade_in, fade_out] = fade.split(',').map(x=>parseInt(x));
+	let [fade_in, fade_out] = fade.split(",").map(x=>parseInt(x));
 	if(fade_out === undefined) fade_out=fade_in;
 	if(fade_in == 0 && fade_out == 0) {
-		return '';
+		return "";
 	} else {
 		return `\\fad(${fade_in},${fade_out})`;
 	}
 }
 
 function displayremoveToDisplayRemove(displayremove: string) {
-	let [display, remove] = displayremove.split(',').map(x=>parseInt(x));
+	let [display, remove] = displayremove.split(",").map(x=>parseInt(x));
 	if(remove === undefined) remove=display;
 	return [display, remove]
 }
@@ -24,9 +24,9 @@ async function mainCLI() {
 
 	// TODO: Possibly only read the file in if track_offset is needed
 	let track_offset = 0;
-	if ('APPDATA' in process.env ) {
+	if ("APPDATA" in process.env ) {
 		try {
-			const settings = readFileSync(process.env.APPDATA + '/Karaoke Builder/data_studio.ini', 'utf8');
+			const settings = readFileSync(process.env.APPDATA + "/Karaoke Builder/data_studio.ini", "utf8");
 			track_offset = parseFloat(settings.match(/^setoffset\s+(\S+)/m)[1]) / 100;
 		} catch (error) {
 
@@ -39,11 +39,11 @@ async function mainCLI() {
 	const yargsInstance = yargs(hideBin(process.argv))
 
 	const argv = yargsInstance
-		.scriptName('kbp2ass')
+		.scriptName("kbp2ass")
 		.parserConfiguration({
-			'camel-case-expansion': false,
-			'duplicate-arguments-array': false,
-			'strip-aliased': true
+			"camel-case-expansion": false,
+			"duplicate-arguments-array": false,
+			"strip-aliased": true
 		})
 		// Unable to use .positional handling because yargs inexplicably treats "$0 foo bar" differently from "$0 -- foo bar"
 		.usage(`$0 [options] [--] [infile [outfile]]
@@ -59,134 +59,134 @@ async function mainCLI() {
 		        Disable any boolean option with --no-[option]`)
 		// Used for compatibility with old syntax allowing minimum-progression-duration as a positional
 		// .positional only includes items before --, so this is how to tell if the second argument is before -- or not
-		.command('* [compat1] [compat2]', false, function(yargs) {
-			yargs.positional('compat1', {
-				type: 'string'
+		.command("* [compat1] [compat2]", false, function(yargs) {
+			yargs.positional("compat1", {
+				type: "string"
 			})
-				.positional('compat2', {
-					type: 'string'
+				.positional("compat2", {
+					type: "string"
 				});
 		})
 		// Despite the fact that the second argument to .command is false,
 		// positionals on the "default" command are still shown unless explicitly hidden
-		.hide('compat1')
-		.hide('compat2')
+		.hide("compat1")
+		.hide("compat2")
 		.options({
-			'syllable-precision': {
-				alias: 's',
-				description: 'Highlight syllables individually instead of combining lines into a single string. Disabling this is not recommended.',
-				type: 'boolean',
+			"syllable-precision": {
+				alias: "s",
+				description: "Highlight syllables individually instead of combining lines into a single string. Disabling this is not recommended.",
+				type: "boolean",
 				default: true,
 				// "nargs: 0" alone doesn't seem to be enough to stop a flag from consuming a parameter next to it
 				requiresArg: false,
 				nargs: 0
 			},
-			'minimum-progression-duration': {
-				alias: ['m', 'wipe-threshold'],
-				description: 'Set threshold of syllable display time in milliseconds before using progressive wipe effect (implicit default 1000)',
-				type: 'number',
+			"minimum-progression-duration": {
+				alias: ["m", "wipe-threshold"],
+				description: "Set threshold of syllable display time in milliseconds before using progressive wipe effect (implicit default 1000)",
+				type: "number",
 				requiresArg: true
 			},
-			'full-mode': {
-				alias: 'f',
+			"full-mode": {
+				alias: "f",
 				description: 'Enable processing of all positional and style information in the KBS project file (-w, -p, -b, -c, -t, -D -1). To unset any particular options use --no-{option}. For example, to run in full mode but with no border set, use "-f --no-b" or "--full-mode --no-border".',
-				type: 'boolean',
+				type: "boolean",
 				requiresArg: false,
 				nargs: 0
 			},
-			'cdg': {
-				alias: 'c',
-				description: 'Set the virtual resolution of the destination file to that of CDG graphics, enabling positioning, alignment, and font size to work as they do in KBS.',
-				type: 'boolean',
+			"cdg": {
+				alias: "c",
+				description: "Set the virtual resolution of the destination file to that of CDG graphics, enabling positioning, alignment, and font size to work as they do in KBS.",
+				type: "boolean",
 				requiresArg: false,
 				nargs: 0
 			},
-			'wipe': {
-				alias: 'w',
-				description: 'Use wipe setting from project file (progressive wipe effect unless wiping is set to word by word). Sets -m to 0 if not otherwise set.',
-				type: 'boolean',
+			"wipe": {
+				alias: "w",
+				description: "Use wipe setting from project file (progressive wipe effect unless wiping is set to word by word). Sets -m to 0 if not otherwise set.",
+				type: "boolean",
 				requiresArg: false,
 				nargs: 0
 			},
-			'position': {
-				alias: 'p',
-				description: 'Use position data from project file. This includes alignment as well as vertical/horizontal offset. Strongly recommended to use with -c option.',
-				type: 'boolean',
+			"position": {
+				alias: "p",
+				description: "Use position data from project file. This includes alignment as well as vertical/horizontal offset. Strongly recommended to use with -c option.",
+				type: "boolean",
 				requiresArg: false,
 				nargs: 0
 			},
-			'border': {
-				alias: 'b',
-				description: 'Use default CDG border (12 pixels from top of screen). If -c option is used, these are virtual pixels. To use a custom border, set --no-border and add a border in your video editor of choice.',
-				type: 'boolean',
+			"border": {
+				alias: "b",
+				description: "Use default CDG border (12 pixels from top of screen). If -c option is used, these are virtual pixels. To use a custom border, set --no-border and add a border in your video editor of choice.",
+				type: "boolean",
 				requiresArg: false,
 				nargs: 0
 			},
-			'fade': {
-				alias: 'F',
-				description: 'Fade-in/out duration for line display in milliseconds. Defaults to 300,200. If only one number is specified it is used for both fade in and out. If 0 or 0,0 is specified, fade effect is disabled entirely.',
-				type: 'string',
+			"fade": {
+				alias: "F",
+				description: "Fade-in/out duration for line display in milliseconds. Defaults to 300,200. If only one number is specified it is used for both fade in and out. If 0 or 0,0 is specified, fade effect is disabled entirely.",
+				type: "string",
 				requiresArg: true,
 				nargs: 1
 			},
-			'displayremove': {
-				alias: 'D',
-				description: 'Timing for line display/remove in milliseconds. Defaults to 1000,100. Note that this time includes the fade, so e.g. fade in of 300 and display of 1000 means that the line fades in for 300ms, then continues displaying at full opacity for 700ms before wiping starts. If only one number is specified it is used for both display and remove. If -1 is specified for either parameter, display/remove timings from the .kbp are used.',
-				type: 'string',
+			"displayremove": {
+				alias: "D",
+				description: "Timing for line display/remove in milliseconds. Defaults to 1000,100. Note that this time includes the fade, so e.g. fade in of 300 and display of 1000 means that the line fades in for 300ms, then continues displaying at full opacity for 700ms before wiping starts. If only one number is specified it is used for both display and remove. If -1 is specified for either parameter, display/remove timings from the .kbp are used.",
+				type: "string",
 				requiresArg: true,
 				nargs: 1
 			},
-			'width': {
-				alias: 'W',
-				description: 'Override the width in the virtual resolution. E.g. set to 384 to get 16:9 aspect ratio if border is enabled, and 341 if it\'s not. This only has any effect with the --cdg option enabled.',
-				type: 'number',
+			"width": {
+				alias: "W",
+				description: "Override the width in the virtual resolution. E.g. set to 384 to get 16:9 aspect ratio if border is enabled, and 341 if it's not. This only has any effect with the --cdg option enabled.",
+				type: "number",
 				requiresArg: true,
 				nargs: 1
 			},
-			'transparency': {
-				alias: 't',
-				description: 'When using palette color 0, always treat it as transparent. This more closely models the behavior KBS uses when generating a CDG, because drawing in the background color XORs with 0, thus not updating the screen. This setting will only be noticeable if you overlap text or render the .ass against a different background color than is defined in the kbp file (or overlay an image/video).',
-				type: 'boolean',
+			"transparency": {
+				alias: "t",
+				description: "When using palette color 0, always treat it as transparent. This more closely models the behavior KBS uses when generating a CDG, because drawing in the background color XORs with 0, thus not updating the screen. This setting will only be noticeable if you overlap text or render the .ass against a different background color than is defined in the kbp file (or overlay an image/video).",
+				type: "boolean",
 				requiresArg: false,
 				nargs: 0
 			},
-			'offset': {
-				alias: 'o',
-				description: 'Amount of seconds to adjust the timings in the .ass file. This can be used to match the offset configured in the KBS Studio Settings or to add time for an intro video. A negative number means to adjust the timings to occur before the time specified in the .kbp file. If not specified, the program will attempt to read from the KBS configuration file in %AppData%\\Karaoke Builder\\data_studio.ini. If unable, it will be set to 0. Note that the default setting in KBS is -0.2 seconds, but it is recommended to set it to 0 to make the .kbp files contain the true timing. If this offset would make any display/remove or wipe timings negative, those become 0.',
-				type: 'number',
+			"offset": {
+				alias: "o",
+				description: "Amount of seconds to adjust the timings in the .ass file. This can be used to match the offset configured in the KBS Studio Settings or to add time for an intro video. A negative number means to adjust the timings to occur before the time specified in the .kbp file. If not specified, the program will attempt to read from the KBS configuration file in %AppData%\\Karaoke Builder\\data_studio.ini. If unable, it will be set to 0. Note that the default setting in KBS is -0.2 seconds, but it is recommended to set it to 0 to make the .kbp files contain the true timing. If this offset would make any display/remove or wipe timings negative, those become 0.",
+				type: "number",
 				requiresArg: true
 			}
 		})
 		.strictOptions()
 		.check(function (argv) {
 			let err=false;
-			let f = argv['fade']?.split(',');
-			let d = argv['displayremove']?.split(',');
+			let f = argv["fade"]?.split(",");
+			let d = argv["displayremove"]?.split(",");
 			// Setting the type only makes it parse it as a number, it doesn't validate the result
-			if(isNaN(argv['minimum-progression-duration'])) {
-				throw new Error('--minimum-progression-duration must be a number');
+			if(isNaN(argv["minimum-progression-duration"])) {
+				throw new Error("--minimum-progression-duration must be a number");
 				err=true;
 			}
-			if('width' in argv && (isNaN(argv['width']) || ! Number.isInteger(argv['width']) || argv['width'] < 1)) {
-				throw new Error('--width must be a positive integer');
+			if("width" in argv && (isNaN(argv["width"]) || ! Number.isInteger(argv["width"]) || argv["width"] < 1)) {
+				throw new Error("--width must be a positive integer");
 				err=true;
 			}
 			if (argv._.length > 2) {
-				throw new Error('Maximum of 2 files may be specified (infile and outfile)');
+				throw new Error("Maximum of 2 files may be specified (infile and outfile)");
 				err=true;
 			}
 			if (f.length < 1 || f.length > 2 || f.some(x=>isNaN(parseInt(x)) || parseInt(x) < 0)){
-				throw new Error('--fade must have 1-2 non-negative integer fade durations specified');
+				throw new Error("--fade must have 1-2 non-negative integer fade durations specified");
 				err=true;
 			}
 			if (d.length < 1 || d.length > 2 || d.some(x=>isNaN(parseInt(x)) || parseInt(x) < -1)){
-				throw new Error('--displayremove must have 1-2 non-negative or -1 integer display durations specified');
+				throw new Error("--displayremove must have 1-2 non-negative or -1 integer display durations specified");
 				err=true;
 			}
 			return !err;
 		})
 		.middleware(function (argv) {
-			if (argv['full-mode']) {
+			if (argv["full-mode"]) {
 				argv = {
 					wipe: true,
 					position: true,
@@ -199,53 +199,51 @@ async function mainCLI() {
 			}
 			if (argv.wipe) {
 				argv = {
-					'minimum-progression-duration': 0,
+					"minimum-progression-duration": 0,
 					...argv
 				}
 			}
-			if ('compat2' in argv) {
+			if ("compat2" in argv) {
 				if (isNaN(parseInt(argv.compat2))) {
 					argv._.unshift(argv.compat2);
 				} else {
-					argv['minimum-progression-duration'] = parseInt(argv.compat2);
+					argv["minimum-progression-duration"] = parseInt(argv.compat2);
 				}
 				delete argv.compat2;
 			}
-			if ('compat1' in argv) {
+			if ("compat1" in argv) {
 				argv._.unshift(argv.compat1);
 				delete argv.compat1;
 			}
 			// "default" functionality from yargs cannot be used because it doesn't show whether a user set the value or the default set it
-			const default_opts = ['wipe', 'position', 'border', 'cdg', 'full-mode', 'transparency'];
+			const default_opts = ["wipe", "position", "border", "cdg", "full-mode", "transparency"];
 			for(let x in default_opts)
 			{
 				const opt = default_opts[x];
 				if (! (opt in argv)) argv[opt]=false;
 			}
-			if (! ('minimum-progression-duration' in argv)) {
-				argv['minimum-progression-duration']=1000;
+			if (! ("minimum-progression-duration" in argv)) {
+				argv["minimum-progression-duration"]=1000;
 			} 
-			if (! ('fade' in argv)) {
-				argv['fade']="300,200";
+			if (! ("fade" in argv)) {
+				argv["fade"]="300,200";
 			} 
-			if (! ('displayremove' in argv)) {
-				argv['displayremove']="1000,100";
+			if (! ("displayremove" in argv)) {
+				argv["displayremove"]="1000,100";
 			} 
-			if (! ('offset' in argv)) {
-				argv['offset']= track_offset || 0;
+			if (! ("offset" in argv)) {
+				argv["offset"]= track_offset || 0;
 			}
 			return argv;
 		}, true)
 		.wrap(yargsInstance.terminalWidth())
 		.argv;
 
-	//console.error("offset is: " + argv.offset);
-
-	let infile = argv._.shift() || '-';
-	// const outfile = argv._.shift() || '-';
+	let infile = argv._.shift() || "-";
+	// const outfile = argv._.shift() || "-";
 
 	delete argv._;
-	delete argv['$0'];
+	delete argv["$0"];
 
 	argv.dialogueScript = fadeToDialogueScript(argv.fade);
 	delete argv.fade;
@@ -256,9 +254,9 @@ async function mainCLI() {
 	// This should be updated to work on Windows, but it would involve some extra
 	// work because even though readFile can take a file descriptor, it doesn't seem
 	// to work as expected with process.stdin.fd
-	if (infile == '-') infile = '/dev/stdin';
+	if (infile == "-") infile = "/dev/stdin";
 
-	const txt = readFileSync(infile, 'utf8');
+	const txt = readFileSync(infile, "utf8");
 
 	return convertToASS(txt, argv);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,10 @@ function generateASSLine(line: any, options: ConverterConfig) {
 	// Horizontal offset only makes sense when there is a set number of pixels to center across
 	const hOffset = (options.cdg || line.alignment != 8) ? line.hpos : 0;
 	const pos = options.position ? '\\pos(' + hOffset + ',' + line.vpos + ')' : '';
+	// TODO: calculate rotation origin if not left-aligned to match KBS?
+	const rot = options.position && line.rotation != 0 ? `\\frz${line.rotation}` : '';
 	// TODO: only use \anX when it differs from style? Currently line only stores style name, and style detail is not passed in.
-	dialogue.value.Text = `{\\an${line.alignment}${pos}\\k${(firstStart - startMs) / 10}${options.dialogueScript}}` + ASSLine.join('');
+	dialogue.value.Text = `{\\an${line.alignment}${pos}${rot}\\k${(firstStart - startMs) / 10}${options.dialogueScript}}` + ASSLine.join('');
 	dialogue.value.Effect = 'fx';
 	dialogue.value.Style = line.currentStyle;
 	comment.value.Text = ASSLine.join('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import  yargs from "yargs";
+import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { readFileSync } from "node:fs";
 import { convertToASS } from "./ass";
@@ -22,17 +22,17 @@ function displayremoveToDisplayRemove(displayremove: string) {
 
 async function mainCLI() {
 
-  // TODO: Either 1) only read the file in if track_offset is needed or 2) find other necessary settings to read
-  let track_offset = 0;
-  if ('APPDATA' in process.env ) {
-	try {
-		const settings = readFileSync(process.env.APPDATA + '/Karaoke Builder/data_studio.ini', 'utf8');
-		track_offset = parseFloat(settings.match(/^setoffset\s+(\S+)/m)[1]) / 100;
-	} catch (error) {
-		
-	}
+	// TODO: Possibly only read the file in if track_offset is needed
+	let track_offset = 0;
+	if ('APPDATA' in process.env ) {
+		try {
+			const settings = readFileSync(process.env.APPDATA + '/Karaoke Builder/data_studio.ini', 'utf8');
+			track_offset = parseFloat(settings.match(/^setoffset\s+(\S+)/m)[1]) / 100;
+		} catch (error) {
 
-  }
+		}
+
+}
 
 	// Per yargs docs, use of terminalWidth() in typescript requires workaround
 	// of assigning a variable name to the instance so it can be referenced
@@ -150,18 +150,18 @@ async function mainCLI() {
 				requiresArg: false,
 				nargs: 0
 			},
-      'offset': {
-        alias: 'o',
-        description: 'Amount of seconds to adjust the timings in the .ass file. This can be used to match the offset configured in the KBS Studio Settings or to add time for an intro video. A negative number means to adjust the timings to occur before the time specified in the .kbp file. If not specified, the program will attempt to read from the KBS configuration file in %AppData%\\Karaoke Builder\\data_studio.ini. If unable, it will be set to 0. Note that the default setting in KBS is -0.2 seconds, but it is recommended to set it to 0 to make the .kbp files contain the true timing. If this offset would make any display/remove or wipe timings negative, those become 0.',
-        type: 'number',
-        requiresArg: true
-      }
+			'offset': {
+				alias: 'o',
+				description: 'Amount of seconds to adjust the timings in the .ass file. This can be used to match the offset configured in the KBS Studio Settings or to add time for an intro video. A negative number means to adjust the timings to occur before the time specified in the .kbp file. If not specified, the program will attempt to read from the KBS configuration file in %AppData%\\Karaoke Builder\\data_studio.ini. If unable, it will be set to 0. Note that the default setting in KBS is -0.2 seconds, but it is recommended to set it to 0 to make the .kbp files contain the true timing. If this offset would make any display/remove or wipe timings negative, those become 0.',
+				type: 'number',
+				requiresArg: true
+			}
 		})
 		.strictOptions()
 		.check(function (argv) {
 			let err=false;
 			let f = argv['fade']?.split(',');
-            let d = argv['displayremove']?.split(',');
+			let d = argv['displayremove']?.split(',');
 			// Setting the type only makes it parse it as a number, it doesn't validate the result
 			if(isNaN(argv['minimum-progression-duration'])) {
 				throw new Error('--minimum-progression-duration must be a number');
@@ -193,7 +193,7 @@ async function mainCLI() {
 					border: true,
 					cdg: true,
 					transparency: true,
-                    displayremove: "-1",
+					displayremove: "-1",
 					...argv
 				}
 			}
@@ -231,14 +231,14 @@ async function mainCLI() {
 			if (! ('displayremove' in argv)) {
 				argv['displayremove']="1000,100";
 			} 
-      if (! ('offset' in argv)) {
-        argv['offset']= track_offset || 0;
-      }
+			if (! ('offset' in argv)) {
+				argv['offset']= track_offset || 0;
+			}
 			return argv;
 		}, true)
 		.wrap(yargsInstance.terminalWidth())
 		.argv;
-  
+
 	//console.error("offset is: " + argv.offset);
 
 	let infile = argv._.shift() || '-';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ function fadeToDialogueScript(fade: string) {
 function displayremoveToDisplayRemove(displayremove: string) {
 	let [display, remove] = displayremove.split(",").map(x=>parseInt(x));
 	if(remove === undefined) remove=display;
-	return [display, remove]
+	return [display, remove];
 }
 
 async function mainCLI() {
@@ -32,11 +32,11 @@ async function mainCLI() {
 
 		}
 
-}
+	}
 
 	// Per yargs docs, use of terminalWidth() in typescript requires workaround
 	// of assigning a variable name to the instance so it can be referenced
-	const yargsInstance = yargs(hideBin(process.argv))
+	const yargsInstance = yargs(hideBin(process.argv));
 
 	const argv = yargsInstance
 		.scriptName("kbp2ass")
@@ -195,13 +195,13 @@ async function mainCLI() {
 					transparency: true,
 					displayremove: "-1",
 					...argv
-				}
+				};
 			}
 			if (argv.wipe) {
 				argv = {
 					"minimum-progression-duration": 0,
 					...argv
-				}
+				};
 			}
 			if ("compat2" in argv) {
 				if (isNaN(parseInt(argv.compat2))) {
@@ -217,8 +217,7 @@ async function mainCLI() {
 			}
 			// "default" functionality from yargs cannot be used because it doesn't show whether a user set the value or the default set it
 			const default_opts = ["wipe", "position", "border", "cdg", "full-mode", "transparency"];
-			for(let x in default_opts)
-			{
+			for(let x in default_opts) {
 				const opt = default_opts[x];
 				if (! (opt in argv)) argv[opt]=false;
 			}
@@ -248,8 +247,8 @@ async function mainCLI() {
 	argv.dialogueScript = fadeToDialogueScript(argv.fade);
 	delete argv.fade;
 
-	[argv.display, argv.remove] = displayremoveToDisplayRemove(argv.displayremove)
-	delete argv.displayremove
+	[argv.display, argv.remove] = displayremoveToDisplayRemove(argv.displayremove);
+	delete argv.displayremove;
 
 	// This should be updated to work on Windows, but it would involve some extra
 	// work because even though readFile can take a file descriptor, it doesn't seem

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import KBPParser from './kbp';
 import stringify from 'ass-stringify';
 import { StyleElement, SyllabesConfig } from './types';
 import ass = require('./assTemplate');
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 function generateASSLine(line: any, options: SyllabesConfig) {
 	const ASSLine = [];
@@ -87,7 +89,7 @@ export function convertToASS(time: string, options: SyllabesConfig): string {
 	const comments = [];
 
 	const styles = clone(ass.styles);
-	styles.body = styles.body.concat(kbp.styles.length > 0 ? kbp.styles.map(style => getStyleAss(style)) :  [ass.defaultStyle]);
+	styles.body = styles.body.concat(kbp.styles.length > 0 ? kbp.styles.map(style => getStyleAss(style)) :	[ass.defaultStyle]);
 	const script = clone(ass.dialogue);
 	script.value.Effect = ass.scriptFX;
 	script.value.Text = ass.script;
@@ -106,22 +108,108 @@ export function convertToASS(time: string, options: SyllabesConfig): string {
 }
 
 async function mainCLI() {
-	if (!process.argv[2]) {
-		throw `KBP2ass - Convert KBP karaoke to ASS file
-		Usage: kbp2ass myfile.txt
-		Output goes to stdout
-		`;
-	}
-	const txtFile = process.argv[2];
 
-	if (process.argv[3] && isNaN(parseInt(process.argv[3]))) throw 'minimum_progression_duration is not a number';
-	const minimum_progression_duration = process.argv[3] ? parseInt(process.argv[3]) : 1000;
 
-	if (!await asyncExists(txtFile)) throw `File ${txtFile} does not exist`;
-	const txt = await asyncReadFile(txtFile, 'utf8');
-	return convertToASS(txt, { syllable_precision: true, minimum_progression_duration });
+	// Per yargs docs, use of terminalWidth() in typescript requires workaround
+	// of assigning a variable name to the instance so it can be referenced
+	const yargsInstance = yargs(hideBin(process.argv))
+
+	const argv = yargsInstance
+		.scriptName('kbp2ass')
+		.parserConfiguration({
+			'camel-case-expansion': false,
+			'duplicate-arguments-array': false,
+			'strip-aliased': true
+		})
+		// Unable to use .positional handling because yargs inexplicably treats "$0 foo bar" differently from "$0 -- foo bar"
+		.usage(`$0 [options] [--] [infile [outfile]]
+		        $0 [options] infile minimum-progression-duration [--] [outfile] 
+
+		        Convert file from KBS project format (.kbp) to SubStation Alpha subtitle (.ass)
+
+		        infile:	input file in .kbp format (stdin if not specified)
+		        outfile: output file in .ass format (stdout if not specified)
+
+		        For compatibility with older releases, minimum-progression-duration can be specified as a positional parameter instead of an option (if both are specified, the positional wins). If your output file name happens to be a number, use -- at some point before the second positional parameter to disable this functionality.
+
+		        Disable any boolean option with --no-[option]`)
+		// Used for compatibility with old syntax allowing minimum-progression-duration as a positional
+		// .positional only includes items before --, so this is how to tell if the second argument is before -- or not
+		.command('* [compat1] [compat2]', false, function(yargs) {
+			yargs.positional('compat1', {})
+			     .positional('compat2', {});
+		})
+		// Despite the fact that the second argument to .command is false,
+		// positionals on the "default" command are still shown unless explicitly hidden
+		.hide('compat1')
+		.hide('compat2')
+		.options({
+			'syllable-precision': {
+				alias: 's',
+				description: 'Highlight syllables individually instead of combining lines into a single string. Disabling this is not recommended.',
+				type: 'boolean',
+				default: true,
+				// "nargs: 0" alone doesn't seem to be enough to stop a flag from consuming a parameter next to it
+				requiresArg: false,
+				nargs: 0
+			},
+			'minimum-progression-duration': {
+				alias: ['m', 'wipe-threshold'],
+				description: 'Set threshold of syllable display time in milliseconds before using progressive wipe effect (implicit default 1000)',
+				type: 'number',
+				requiresArg: true
+			}
+		})
+		.strictOptions()
+		.check(function (argv) {
+			// Setting the type only makes it parse it as a number, it doesn't validate the result
+			if(isNaN(argv['minimum-progression-duration'])) {
+				throw new Error('--minimum-progression-duration must be a number');
+			}
+			else if (argv._.length > 2) {
+				throw new Error('Maximum of 2 files may be specified (infile and outfile)');
+			} else {
+				return true;
+			}
+
+		})
+		.middleware(function (argv) {
+			if (argv.compat1) {
+				argv._.unshift(argv.compat1);
+				delete argv.compat1;
+			}
+			if (argv.compat2) {
+				if (isNaN(parseInt(argv.compat2))) {
+					argv._.unshift(argv.compat1);
+				} else {
+					argv['minimum-progression-duration'] = argv.compat2;
+				}
+				delete argv.compat2;
+			}
+			if (! ('minimum-progression-duration' in argv)) {
+				argv['minimum-progression-duration']=1000;
+			} 
+			return argv;
+		}, true)
+		.wrap(yargsInstance.terminalWidth())
+		.argv;
+
+	argv.infile = argv._.shift() || '-';
+	argv.outfile = argv._.shift() || '-';
+
+	// This should be updated to work on Windows, but it would involve some extra
+	// work because even though readFile can take a file descriptor, it doesn't seem
+	// to work as expected with process.stdin.fd
+	if (argv.infile == '-') argv.infile = '/dev/stdin';
+
+	const minimum_progression_duration = Math.floor(argv['minimum-progression-duration']);
+
+	if(! await asyncExists(argv.infile)) throw `File ${argv.infile} does not exist`;
+	const txt = await asyncReadFile(argv.infile, 'utf8');
+
+	return convertToASS(txt, { syllable_precision: argv['syllable-precision'], minimum_progression_duration });
 }
 
 if (require.main === module) mainCLI()
 	.then(data => console.log(data))
-	.catch(err => console.log(err));
+	.catch(err => console.error(err));

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -215,9 +215,6 @@ export default class KBPParser {
 				// Get the syllable text
 				syllable.text = matches[0];
 
-				// A leading space at the start of a line needs to be replaced with a hard break to function
-				if(syllables.length == 0) syllable.text = syllable.text.replace(/^ /,'\\h');
-
 				// Add the start time of the syllable
 
 				// TODO: Better handling of fixed text. Currently this will just set

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -73,6 +73,7 @@ export default class KBPParser {
 		let currentAlignment = null;
 		let defaultWipeProgressive = null;
 		let fixed = null;
+		let rotation = null;
 
 		// We split blocks by PAGEV2, and ignore the first one (it is header)
 		let blockcount = 0;
@@ -154,12 +155,12 @@ export default class KBPParser {
 				continue;
 			}
 
-			// TODO: rotation
 			// TODO: transitions?
 			if (line.match(/[LCR]\/[A-Za-z]/g)?.length > 0) {
 				let element = line.split('/');
 				currentPos += lineSpacing;
 				currentOffset = parseInt(element[5]);
+				rotation = parseInt(element[6]);
 				currentAlignment = this.getAlignement(element[0]);
 				horizontalPos = (currentAlignment - 7) * totalWidth / 2 + parseInt(element[4]) +
 												(8 - currentAlignment) * (
@@ -184,7 +185,7 @@ export default class KBPParser {
 			if (line.replace(/\s*/g, '').length == 0) {
 				if (syllables.length > 0) {
 					// Create a new sentence
-					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle, currentPos + currentOffset, horizontalPos, currentAlignment);
+					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle, currentPos + currentOffset, horizontalPos, currentAlignment, rotation);
 
 					currentStart = null;
 					currentEnd = null;
@@ -256,7 +257,7 @@ export default class KBPParser {
 	 * @param {number} hpos        Horizontal position to draw sentence
 	 * @param {number} alignment   Text alignment of sentence
 	 */
-	private makeSentence(id: number, syllables: any[], start: number, end: number, currentStyle: string, vpos: number, hpos: number, alignment: number) {
+	private makeSentence(id: number, syllables: any[], start: number, end: number, currentStyle: string, vpos: number, hpos: number, alignment: number, rotation: number) {
 		var sentence: any = {
 			id: id,
 			start: syllables[0].start,
@@ -264,7 +265,8 @@ export default class KBPParser {
 			currentStyle: currentStyle,
 			vpos: vpos,
 			hpos: hpos,
-			alignment: alignment
+			alignment: alignment,
+      rotation: rotation
 		};
 
 		// Insert sentence syllables as objects or as a string

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -55,7 +55,7 @@ export default class KBPParser {
 		let currentEnd = null;		// End of the previous sentence (milliseconds)
 		let syllables = [];			// Syllables list of the current sentence
 		let colours = null;			// list of colours
-		let currentStyle: string = null;	// Current style
+		let currentStyle: IStyle = null;	// Current style
 
 		// Below are defaults from KBS, they should get replaced by the Margins config line
 		let leftMargin = 2;
@@ -167,8 +167,8 @@ export default class KBPParser {
 													(currentAlignment == 7 ? leftMargin : rightMargin) + 
 													(this.config.border ? 6 : 0));
 				if (element[2] !== '0' && element[3] !== '0') {
-					this.styles[element[1].toUpperCase().charCodeAt(0) - 65].Alignment = currentAlignment;
-					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65].Name;
+					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65] ?? this.styles[0];
+					currentStyle.Alignment = currentAlignment;
 				}
 				fixed = (element[1].toLowerCase() == element[1]);
 				currentStart = Math.floor(parseInt(element[2]) * 10) + offsetms;
@@ -187,7 +187,7 @@ export default class KBPParser {
 			if (line.replace(/\s*/g, '').length == 0) {
 				if (syllables.length > 0) {
 					// Create a new sentence
-					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle, currentPos + currentOffset, horizontalPos, currentAlignment);
+					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle.Name, currentPos + currentOffset, horizontalPos, currentAlignment);
 
 					currentStart = null;
 					currentEnd = null;
@@ -266,7 +266,7 @@ export default class KBPParser {
     syllables: ISyllable[],
     start: number,
     end: number,
-    currentStyle: string,
+    styleName: string,
     vpos: number,
     hpos: number,
     alignment: number
@@ -279,7 +279,7 @@ export default class KBPParser {
       start,
       end,
       duration,
-      currentStyle,
+      styleName,
       vpos,
       hpos,
       alignment,

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -18,7 +18,7 @@ export default class KBPParser {
 		const start = index == 0 && this.config.transparency? "&HFF" : "&H00";
 		return start + palette[index].split("").reverse().map(function (hex) {
 			return hex + hex;
-			}).join("");
+		}).join("");
 	}
 
 	getAlignement(element: string) {
@@ -85,7 +85,7 @@ export default class KBPParser {
 
 			if (line == "PAGEV2") {
 				blockcount++;
-				currentPos = topMargin - lineSpacing // line is read before the applicable syllables start, so it will add back lineSpacing
+				currentPos = topMargin - lineSpacing; // line is read before the applicable syllables start, so it will add back lineSpacing
 				continue;
 			}
 
@@ -109,7 +109,7 @@ export default class KBPParser {
 				continue;
 			}
 
-			let matches = line.match(/Style([0-1][0-9])/)
+			let matches = line.match(/Style([0-1][0-9])/);
 			if (matches?.length > 0) {
 				// Style numbers can be skipped and possibly don't even need to be sequential
 				let index = parseInt(matches[1]);
@@ -174,7 +174,7 @@ export default class KBPParser {
 				currentAlignment = this.getAlignement(element[0]);
 				horizontalPos = (currentAlignment - 7) * totalWidth / 2 + parseInt(element[4]) +
 					(8 - currentAlignment) * (
-							(currentAlignment == 7 ? leftMargin : rightMargin) + 
+						(currentAlignment == 7 ? leftMargin : rightMargin) + 
 							(this.config.border ? 6 : 0));
 				if (element[2] !== "0" && element[3] !== "0") {
 					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65] ?? this.styles[0];

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -15,19 +15,19 @@ export default class KBPParser {
 	kbp2AssColor(palette: string[], index: number) {
 		// If transparency mode is on, if the palette color used is the background
 		// (always index 0 in kbp format), do not display (full transparency)
-		const start = index == 0 && this.config.transparency? '&HFF' : '&H00';
-		return start + palette[index].split('').reverse().map(function (hex) {
+		const start = index == 0 && this.config.transparency? "&HFF" : "&H00";
+		return start + palette[index].split("").reverse().map(function (hex) {
 			return hex + hex;
-			}).join('');
+			}).join("");
 	}
 
 	getAlignement(element: string) {
 		let alignment = 8;
-		if (element === 'C') {
+		if (element === "C") {
 			alignment = 8;
-		} else if (element === 'L') {
+		} else if (element === "L") {
 			alignment = 7;
-		} else if (element === 'R') {
+		} else if (element === "R") {
 			alignment = 9;
 		}
 		return alignment;
@@ -42,11 +42,11 @@ export default class KBPParser {
 		let regex = /(.*)\/ *([0-9]+)\/([0-9]+)\/([0-9]+)/g;
 
 		if (file.match(regex).length === 0) {
-			throw ('Invalid KaraokeBuilder file');
+			throw ("Invalid KaraokeBuilder file");
 		}
 
 		// Let's parse the file line by line
-		let lines = file.replace(/\r+/g, '').split('\n');
+		let lines = file.replace(/\r+/g, "").split("\n");
 
 		let sentenceID = 1;			// Current sentence ID
 		let trackID = 1;			// Current track ID
@@ -83,7 +83,7 @@ export default class KBPParser {
 			// Delete the trailing spaces
 			let line: string = lines[i].trimEnd();
 
-			if (line == 'PAGEV2') {
+			if (line == "PAGEV2") {
 				blockcount++;
 				currentPos = topMargin - lineSpacing // line is read before the applicable syllables start, so it will add back lineSpacing
 				continue;
@@ -91,7 +91,7 @@ export default class KBPParser {
 
 			if (line.match(/^'Margins/)?.length > 0) {
 				i++;
-				[leftMargin, rightMargin, topMargin, lineSpacing] = lines[i].trim().split(',').map(x => parseInt(x));
+				[leftMargin, rightMargin, topMargin, lineSpacing] = lines[i].trim().split(",").map(x => parseInt(x));
 				topMargin += (this.config.border ? 12 : 0);
 				// TODO: determine the correct value based on style 0 (style 1 in GUI)
 				// 19 is correct for Arial 12 bold, Arial 13, and Arial 13 bold
@@ -100,12 +100,12 @@ export default class KBPParser {
 
 			if (line.match(/^'Other/)?.length > 0) {
 				i++;
-				defaultWipeProgressive = (lines[i].trim().split(',')[1] == '5' ? false : true);
+				defaultWipeProgressive = (lines[i].trim().split(",")[1] == "5" ? false : true);
 			}
 
 			if (line.match(/^'Palette Colours/)?.length > 0) {
 				i++;
-				colours = lines[i].trim().split(',');
+				colours = lines[i].trim().split(",");
 				continue;
 			}
 
@@ -114,7 +114,7 @@ export default class KBPParser {
 				// Style numbers can be skipped and possibly don't even need to be sequential
 				let index = parseInt(matches[1]);
 				// first line of style
-				let element = line.trimStart().split(',');
+				let element = line.trimStart().split(",");
 				let style: IStyle = {
 					Name: `${element[0]}_${element[1]}`,
 					PrimaryColour: this.kbp2AssColor(colours, parseInt(element[4])),
@@ -124,7 +124,7 @@ export default class KBPParser {
 				};
 				i++;
 				// second line of style
-				element = lines[i].trim().split(',');
+				element = lines[i].trim().split(",");
 				style.Fontname = element[0];
 
 				// TODO: improve this based on font used
@@ -141,20 +141,20 @@ export default class KBPParser {
 				// element[2] is empty if no styles are applied, and contains
 				// the letters B, I, S, U for each of bold, italic, strikethrough,
 				// underline
-				style.Bold = element[2].indexOf('B') === -1 ? 0 : -1;
-				style.Italic = element[2].indexOf('I') === -1 ? 0 : -1;
-				style.StrikeOut = element[2].indexOf('S') === -1 ? 0 : -1;
-				style.Underline = element[2].indexOf('U') === -1 ? 0 : -1;
+				style.Bold = element[2].indexOf("B") === -1 ? 0 : -1;
+				style.Italic = element[2].indexOf("I") === -1 ? 0 : -1;
+				style.StrikeOut = element[2].indexOf("S") === -1 ? 0 : -1;
+				style.Underline = element[2].indexOf("U") === -1 ? 0 : -1;
 				style.Encoding = parseInt(element[3]);
 				i++;
 				// third line of style
-				element = lines[i].trim().split(',');
+				element = lines[i].trim().split(",");
 				// 0-3 are left/right/top/bottom outline
 				style.Outline = parseInt(element[0]);
 				// 4-5 are right/down shadow
 				style.Shadow = parseInt(element[4]);
 				// 6 is wiping style (text, outline, both), unused
-				style.AllCaps = element[7] === 'U';
+				style.AllCaps = element[7] === "U";
 				this.styles[index] = style;
 				continue;
 			}
@@ -167,7 +167,7 @@ export default class KBPParser {
 
 			// TODO: transitions?
 			if (line.match(/[LCR]\/[A-Za-z]/g)?.length > 0) {
-				let element = line.split('/');
+				let element = line.split("/");
 				currentPos += lineSpacing;
 				currentOffset = parseInt(element[5]);
 				rotation = parseInt(element[6]);
@@ -176,7 +176,7 @@ export default class KBPParser {
 					(8 - currentAlignment) * (
 							(currentAlignment == 7 ? leftMargin : rightMargin) + 
 							(this.config.border ? 6 : 0));
-				if (element[2] !== '0' && element[3] !== '0') {
+				if (element[2] !== "0" && element[3] !== "0") {
 					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65] ?? this.styles[0];
 					// Push the alignment from the first use of the style into the style
 					currentStyle.Alignment ||= currentAlignment;
@@ -190,12 +190,12 @@ export default class KBPParser {
 			}
 
 			// Ignore block separators FX/F/ statements
-			if (line.startsWith('--------') || line.startsWith('FX/') || line == 'PAGEV2' || line == 'MODS') {
+			if (line.startsWith("--------") || line.startsWith("FX/") || line == "PAGEV2" || line == "MODS") {
 				continue;
 			}
 
 			// Empty line is end of line
-			if (line.replace(/\s*/g, '').length == 0) {
+			if (line.replace(/\s*/g, "").length == 0) {
 				if (syllables.length > 0) {
 					// Create a new sentence
 					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle.Name, currentPos + currentOffset, horizontalPos, currentAlignment == currentStyle.Alignment ? 0 : currentAlignment, rotation);
@@ -220,7 +220,7 @@ export default class KBPParser {
 				var syllable: any = {};
 
 				// Split of the regex result
-				let matches = line.split('/');
+				let matches = line.split("/");
 
 				// Get the syllable text
 				syllable.text = matches[0];

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -246,7 +246,7 @@ export default class KBPParser {
 					syllable.wipeProgressive = (wipeType >= 5 ? false : true);
 				}
 
-				if (currentStyle.AllCaps) {
+				if (currentStyle && currentStyle.AllCaps) {
 					syllable.text = syllable.text.toUpperCase();
 				}
 

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -2,23 +2,23 @@ import { IStyle, IConfig, ISentence, ISyllable } from "./types";
 
 
 export default class KBPParser {
-  config: IConfig;
-  track: ISentence[] | undefined;
-  styles: IStyle[] = [];
+	config: IConfig;
+	track: ISentence[] | undefined;
+	styles: IStyle[] = [];
 
-  constructor(config: IConfig) {
-    this.config = config;
-    this.track = [];
-  }
+	constructor(config: IConfig) {
+		this.config = config;
+		this.track = [];
+	}
 
-  // Convert a 3-hex-digit RGB color to an 8-digit ABGR (backwards RGBA)
+	// Convert a 3-hex-digit RGB color to an 8-digit ABGR (backwards RGBA)
 	kbp2AssColor(palette: string[], index: number) {
 		// If transparency mode is on, if the palette color used is the background
 		// (always index 0 in kbp format), do not display (full transparency)
-    const start = index == 0 && this.config.transparency?  '&HFF':'&H00' ;
-    return start + palette[index].split('').reverse().map(function (hex) {
-      return hex + hex;
-    }).join('');
+		const start = index == 0 && this.config.transparency? '&HFF' : '&H00';
+		return start + palette[index].split('').reverse().map(function (hex) {
+			return hex + hex;
+			}).join('');
 	}
 
 	getAlignement(element: string) {
@@ -38,7 +38,6 @@ export default class KBPParser {
 	 * @param {string} file KBP text file content
 	 */
 	parse(file: string) {
-
 		// Lyric match regex like ZA/						592/622/0
 		let regex = /(.*)\/ *([0-9]+)\/([0-9]+)\/([0-9]+)/g;
 
@@ -74,7 +73,7 @@ export default class KBPParser {
 		let fixed = null;
 		let rotation = null;
 
-    let offsetms = Math.floor(this.config.offset * 1000);
+		let offsetms = Math.floor(this.config.offset * 1000);
 
 		// We split blocks by PAGEV2, and ignore the first one (it is header)
 		let blockcount = 0;
@@ -134,9 +133,9 @@ export default class KBPParser {
 				// for most normal fonts but ideally this should change to
 				// something like this example in Cairo:
 				// https://stackoverflow.com/questions/23252321/freetype-sizing-fonts-based-on-cap-height
-                // Another option is adding a parameter for font scaling
-                // Note: using toFixed to make a reasonable-looking number for the .ass file
-                // even though something like 16.799999999999997 will technically work
+				// Another option is adding a parameter for font scaling
+				// Note: using toFixed to make a reasonable-looking number for the .ass file
+				// even though something like 16.799999999999997 will technically work
 				style.Fontsize = (parseInt(element[1]) * 1.4).toFixed(2);
 
 				// element[2] is empty if no styles are applied, and contains
@@ -174,9 +173,9 @@ export default class KBPParser {
 				rotation = parseInt(element[6]);
 				currentAlignment = this.getAlignement(element[0]);
 				horizontalPos = (currentAlignment - 7) * totalWidth / 2 + parseInt(element[4]) +
-												(8 - currentAlignment) * (
-													(currentAlignment == 7 ? leftMargin : rightMargin) + 
-													(this.config.border ? 6 : 0));
+					(8 - currentAlignment) * (
+							(currentAlignment == 7 ? leftMargin : rightMargin) + 
+							(this.config.border ? 6 : 0));
 				if (element[2] !== '0' && element[3] !== '0') {
 					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65] ?? this.styles[0];
 					// Push the alignment from the first use of the style into the style
@@ -184,9 +183,9 @@ export default class KBPParser {
 				}
 				fixed = (element[1].toLowerCase() == element[1]);
 				currentStart = Math.floor(parseInt(element[2]) * 10) + offsetms;
-        if (currentStart < 0) currentStart = 0;
+				if (currentStart < 0) currentStart = 0;
 				currentEnd = Math.floor(parseInt(element[3]) * 10) + offsetms;
-        if (currentEnd < 0) currentEnd = 0;
+				if (currentEnd < 0) currentEnd = 0;
 				continue;
 			}
 
@@ -233,10 +232,10 @@ export default class KBPParser {
 				// from ever wiping but ideally there should be a fixed version of the
 				// style that does not even use \k or \kf
 				syllable.start = fixed ? currentEnd : Math.floor(parseInt(matches[1].trim()) * 10 + offsetms);
-        if (syllable.start < 0) syllable.start = 0;
+				if (syllable.start < 0) syllable.start = 0;
 				// Add the duration, end time
 				syllable.end = fixed ? syllable.start : Math.floor(parseInt(matches[2].trim()) * 10 + offsetms);
-        if (syllable.end < 0) syllable.end = 0;
+				if (syllable.end < 0) syllable.end = 0;
 				syllable.duration = syllable.end - syllable.start;
 
 				let wipeType = parseInt(matches[3].trim());
@@ -262,46 +261,46 @@ export default class KBPParser {
 		};
 	}
 
-  /**
-   * Make a new sentence
-   * @param {number} id          ID of the sentence
-   * @param {ISyllable[]}  syllables   Syllables list of the sentence
-   * @param {number} start       Start time of the sentence
-   * @param {number} end         End time of the sentence
-   * @param {number} vpos        Vertical position to draw sentence
-   * @param {number} hpos        Horizontal position to draw sentence
-   * @param {number} alignment   Text alignment of sentence
-   * @param {number} rotation    Rotation of the text in degrees
-   */
-  private makeSentence(
-    id: number,
-    syllables: ISyllable[],
-    start: number,
-    end: number,
-    styleName: string,
-    vpos: number,
-    hpos: number,
-    alignment: number,
-    rotation: number
-  ): ISentence {
-    start = start ?? syllables[0].start;
-    end = end ?? syllables[syllables.length - 1].end;
-    const duration = end - start;
-    return {
-      id,
-      start,
-      end,
-      duration,
-      styleName,
-      vpos,
-      hpos,
-      alignment,
-      // Insert sentence syllables as objects or as a string
-      syllables: this.config["syllable-precision"] ? syllables : undefined,
-      text: this.config["syllable-precision"]
-        ? ""
-        : syllables.map(s => s.text).join(""),
-      rotation
-    };
-  }
+	/**
+	 * Make a new sentence
+	 * @param {number} id              ID of the sentence
+	 * @param {ISyllable[]} syllables  Syllables list of the sentence
+	 * @param {number} start           Start time of the sentence
+	 * @param {number} end             End time of the sentence
+	 * @param {number} vpos            Vertical position to draw sentence
+	 * @param {number} hpos            Horizontal position to draw sentence
+	 * @param {number} alignment       Text alignment of sentence
+	 * @param {number} rotation        Rotation of the text in degrees
+	 */
+	private makeSentence(
+		id: number,
+		syllables: ISyllable[],
+		start: number,
+		end: number,
+		styleName: string,
+		vpos: number,
+		hpos: number,
+		alignment: number,
+		rotation: number
+	): ISentence {
+		start = start ?? syllables[0].start;
+		end = end ?? syllables[syllables.length - 1].end;
+		const duration = end - start;
+		return {
+			id,
+			start,
+			end,
+			duration,
+			styleName,
+			vpos,
+			hpos,
+			alignment,
+			// Insert sentence syllables as objects or as a string
+			syllables: this.config["syllable-precision"] ? syllables : undefined,
+			text: this.config["syllable-precision"]
+				? ""
+				: syllables.map(s => s.text).join(""),
+			rotation
+		};
+	}
 }

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -77,6 +77,8 @@ export default class KBPParser {
 		let defaultWipeProgressive = null;
 		let fixed = null;
 
+    let offsetms = Math.floor(this.config.offset * 1000);
+
 		// We split blocks by PAGEV2, and ignore the first one (it is header)
 		let blockcount = 0;
 
@@ -173,8 +175,10 @@ export default class KBPParser {
 					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65].Name;
 				}
 				fixed = (element[1].toLowerCase() == element[1]);
-				currentStart = Math.floor(parseInt(element[2]) * 10);
-				currentEnd = Math.floor(parseInt(element[3]) * 10);
+				currentStart = Math.floor(parseInt(element[2]) * 10) + offsetms;
+        if (currentStart < 0) currentStart = 0;
+				currentEnd = Math.floor(parseInt(element[3]) * 10) + offsetms;
+        if (currentEnd < 0) currentEnd = 0;
 				continue;
 			}
 
@@ -224,9 +228,11 @@ export default class KBPParser {
 				// the time before wiping starts to be the duration of the line to stop it
 				// from ever wiping but ideally there should be a fixed version of the
 				// style that does not even use \k or \kf
-				syllable.start = fixed ? currentEnd : Math.floor(parseInt(matches[1].trim()) * 10);
+				syllable.start = fixed ? currentEnd : Math.floor(parseInt(matches[1].trim()) * 10 + offsetms);
+        if (syllable.start < 0) syllable.start = 0;
 				// Add the duration, end time
-				syllable.end = fixed ? syllable.start : Math.floor(parseInt(matches[2].trim()) * 10);
+				syllable.end = fixed ? syllable.start : Math.floor(parseInt(matches[2].trim()) * 10 + offsetms);
+        if (syllable.end < 0) syllable.end = 0;
 				syllable.duration = syllable.end - syllable.start;
 
 				let wipeType = parseInt(matches[3].trim());

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -105,7 +105,10 @@ export default class KBPParser {
 				continue;
 			}
 
-			if (line.match(/Style[0-1][0-9]/g)?.length > 0) {
+			let matches = line.match(/Style([0-1][0-9])/)
+			if (matches?.length > 0) {
+				// Style numbers can be skipped and possibly don't even need to be sequential
+				let index = parseInt(matches[1]);
 				// first line of style
 				let element = line.split(',');
 				let style: StyleElement = {
@@ -137,7 +140,7 @@ export default class KBPParser {
 				element = lines[i].trim().split(',');
 				style.Outline = parseInt(element[0]);
 				style.Shadow = parseInt(element[4]);
-				this.styles.push(style);
+				this.styles[index] = style;
 				continue;
 			}
 
@@ -215,7 +218,7 @@ export default class KBPParser {
 				if(wipeType == 0) {
 					syllable.wipeProgressive = defaultWipeProgressive;
 				} else {
-					syllable.wipeProgressive = (wipeType == 5 ? false : true);
+					syllable.wipeProgressive = (wipeType >= 5 ? false : true);
 				}
 
 
@@ -233,13 +236,13 @@ export default class KBPParser {
 
 	/**
 	 * Make a new sentence
-   * @param {number} id          ID of the sentence
-   * @param {any[]}  syllables   Syllables list of the sentence
-   * @param {number} start       Start time of the sentence
-   * @param {number} end         End time of the sentence
-   * @param {number} vpos        Vertical position to draw sentence
-   * @param {number} hpos        Horizontal position to draw sentence
-   * @param {number} alignment   Text alignment of sentence
+	 * @param {number} id          ID of the sentence
+	 * @param {any[]}  syllables   Syllables list of the sentence
+	 * @param {number} start       Start time of the sentence
+	 * @param {number} end         End time of the sentence
+	 * @param {number} vpos        Vertical position to draw sentence
+	 * @param {number} hpos        Horizontal position to draw sentence
+	 * @param {number} alignment   Text alignment of sentence
 	 */
 	private makeSentence(id: number, syllables: any[], start: number, end: number, currentStyle: string, vpos: number, hpos: number, alignment: number) {
 		var sentence: any = {

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -139,16 +139,23 @@ export default class KBPParser {
                 // even though something like 16.799999999999997 will technically work
 				style.Fontsize = (parseInt(element[1]) * 1.4).toFixed(2);
 
-				style.Bold = element[2] === 'B' ? -1 : 0;
-				style.Italic = element[2] === 'I' ? -1 : 0;
-				style.StrikeOut = element[2] === 'S' ? -1 : 0;
-				style.Underline = element[2] === 'U' ? -1 : 0;
+				// element[2] is empty if no styles are applied, and contains
+				// the letters B, I, S, U for each of bold, italic, strikethrough,
+				// underline
+				style.Bold = element[2].indexOf('B') === -1 ? 0 : -1;
+				style.Italic = element[2].indexOf('I') === -1 ? 0 : -1;
+				style.StrikeOut = element[2].indexOf('S') === -1 ? 0 : -1;
+				style.Underline = element[2].indexOf('U') === -1 ? 0 : -1;
 				style.Encoding = parseInt(element[3]);
 				i++;
 				// third line of style
 				element = lines[i].trim().split(',');
+				// 0-3 are left/right/top/bottom outline
 				style.Outline = parseInt(element[0]);
+				// 4-5 are right/down shadow
 				style.Shadow = parseInt(element[4]);
+				// 6 is wiping style (text, outline, both), unused
+				style.AllCaps = element[7] === 'U';
 				this.styles[index] = style;
 				continue;
 			}
@@ -239,6 +246,9 @@ export default class KBPParser {
 					syllable.wipeProgressive = (wipeType >= 5 ? false : true);
 				}
 
+				if (currentStyle.AllCaps) {
+					syllable.text = syllable.text.toUpperCase();
+				}
 
 				if (syllable.start !== 0 || syllable.end !== 0) {
 					// Add the syllable

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -212,6 +212,9 @@ export default class KBPParser {
 				// Get the syllable text
 				syllable.text = matches[0];
 
+				// A leading space at the start of a line needs to be replaced with a hard break to function
+				if(syllables.length == 0) syllable.text = syllable.text.replace(/^ /,'\\h');
+
 				// Add the start time of the syllable
 
 				// TODO: Better handling of fixed text. Currently this will just set

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -169,7 +169,8 @@ export default class KBPParser {
 													(this.config.border ? 6 : 0));
 				if (element[2] !== '0' && element[3] !== '0') {
 					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65] ?? this.styles[0];
-					currentStyle.Alignment = currentAlignment;
+					// Push the alignment from the first use of the style into the style
+					currentStyle.Alignment ||= currentAlignment;
 				}
 				fixed = (element[1].toLowerCase() == element[1]);
 				currentStart = Math.floor(parseInt(element[2]) * 10) + offsetms;
@@ -188,7 +189,7 @@ export default class KBPParser {
 			if (line.replace(/\s*/g, '').length == 0) {
 				if (syllables.length > 0) {
 					// Create a new sentence
-					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle.Name, currentPos + currentOffset, horizontalPos, currentAlignment, rotation);
+					let sentence = this.makeSentence(sentenceID, syllables, currentStart, currentEnd, currentStyle.Name, currentPos + currentOffset, horizontalPos, currentAlignment == currentStyle.Alignment ? 0 : currentAlignment, rotation);
 					currentStart = null;
 					currentEnd = null;
 

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -64,7 +64,7 @@ export default class KBPParser {
 		let topMargin = 7 + (this.config.border ? 12 : 0); // margin from KBS plus CDG top border
 		let lineSpacing = 12 + 19; // the effective line spacing seems to add 19 pixels to the value set in KBS
 
-		const totalWidth = this.config.border ? 300 : 288;
+		const totalWidth = this.config.width || (this.config.border ? 300 : 288);
 		
 		// not set until a page starts
 		let currentPos = null;

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -91,7 +91,14 @@ export default class KBPParser {
 				// second line of style
 				element = lines[i].trim().split(',');
 				style.Fontname = element[0];
-				style.Fontsize = element[1];
+
+				// Font size in .kbp refers to the cap height, whereas in .ass it
+				// refers to the line/body height. 1.5 seems to be correct or close
+				// for most normal fonts but ideally this should change to
+				// something like this example in Cairo:
+				// https://stackoverflow.com/questions/23252321/freetype-sizing-fonts-based-on-cap-height
+				style.Fontsize = parseInt(element[1]) * 1.5;
+
 				style.Bold = element[2] === 'B' ? -1 : 0;
 				style.Italic = element[2] === 'I' ? -1 : 0;
 				style.StrikeOut = element[2] === 'S' ? -1 : 0;

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -12,14 +12,17 @@ export default class KBPParser {
 		this.track = [];
 	}
 
-	getSixDigitHexColor(hexcolor: string) {
-		// If a three-character hexcolor, make six-character
-		if (hexcolor.length === 3) {
-			hexcolor = hexcolor.split('').reverse().map(function (hex) {
-				return hex + hex;
-			}).join('');
-		}
-		return hexcolor;
+  // Convert a 3-hex-digit RGB color to an 8-digit ABGR (backwards RGBA)
+	kbp2AssColor(palette: string[], index: number) {
+		// If transparency mode is on, if the palette color used is the background
+		// (always index 0 in kbp format), do not display (full transparency)
+    let start = '&H00'
+		if(index == 0 && this.config.transparency) {
+			start = '&HFF'
+		} 
+    return start + palette[index].split('').reverse().map(function (hex) {
+      return hex + hex;
+    }).join('');
 	}
 
 	getAlignement(element: string) {
@@ -116,10 +119,10 @@ export default class KBPParser {
 				let element = line.split(',');
 				let style: StyleElement = {
 					Name: `${element[0]}_${element[1]}`,
-					PrimaryColour: `&H00${this.getSixDigitHexColor(colours[element[4]])}`,
-					SecondaryColour: `&H00${this.getSixDigitHexColor(colours[element[2]])}`,
-					OutlineColour: `&H00${this.getSixDigitHexColor(colours[element[3]])}`,
-					BackColour: `&H00${this.getSixDigitHexColor(colours[element[5]])}`
+					PrimaryColour: this.kbp2AssColor(colours, parseInt(element[4])),
+					SecondaryColour: this.kbp2AssColor(colours, parseInt(element[2])),
+					OutlineColour: this.kbp2AssColor(colours, parseInt(element[3])),
+					BackColour: this.kbp2AssColor(colours, parseInt(element[5]))
 				};
 				i++;
 				// second line of style

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -115,7 +115,7 @@ export default class KBPParser {
 				// Style numbers can be skipped and possibly don't even need to be sequential
 				let index = parseInt(matches[1]);
 				// first line of style
-				let element = line.split(',');
+				let element = line.trimStart().split(',');
 				let style: IStyle = {
 					Name: `${element[0]}_${element[1]}`,
 					PrimaryColour: this.kbp2AssColor(colours, parseInt(element[4])),
@@ -134,7 +134,10 @@ export default class KBPParser {
 				// for most normal fonts but ideally this should change to
 				// something like this example in Cairo:
 				// https://stackoverflow.com/questions/23252321/freetype-sizing-fonts-based-on-cap-height
-				style.Fontsize = parseInt(element[1]) * 1.4;
+                // Another option is adding a parameter for font scaling
+                // Note: using toFixed to make a reasonable-looking number for the .ass file
+                // even though something like 16.799999999999997 will technically work
+				style.Fontsize = (parseInt(element[1]) * 1.4).toFixed(2);
 
 				style.Bold = element[2] === 'B' ? -1 : 0;
 				style.Italic = element[2] === 'I' ? -1 : 0;

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -1,25 +1,21 @@
-import { StyleElement, ConverterConfig } from './types';
+import { IStyle, IConfig, ISentence, ISyllable } from "./types";
 
 
 export default class KBPParser {
+  config: IConfig;
+  track: ISentence[] | undefined;
+  styles: IStyle[] = [];
 
-	config: ConverterConfig;
-	track: any;
-	styles: StyleElement[] = [];
-
-	constructor(config: ConverterConfig) {
-		this.config = config;
-		this.track = [];
-	}
+  constructor(config: IConfig) {
+    this.config = config;
+    this.track = [];
+  }
 
   // Convert a 3-hex-digit RGB color to an 8-digit ABGR (backwards RGBA)
 	kbp2AssColor(palette: string[], index: number) {
 		// If transparency mode is on, if the palette color used is the background
 		// (always index 0 in kbp format), do not display (full transparency)
-    let start = '&H00'
-		if(index == 0 && this.config.transparency) {
-			start = '&HFF'
-		} 
+    const start = index == 0 && this.config.transparency?  '&HFF':'&H00' ;
     return start + palette[index].split('').reverse().map(function (hex) {
       return hex + hex;
     }).join('');
@@ -119,7 +115,7 @@ export default class KBPParser {
 				let index = parseInt(matches[1]);
 				// first line of style
 				let element = line.split(',');
-				let style: StyleElement = {
+				let style: IStyle = {
 					Name: `${element[0]}_${element[1]}`,
 					PrimaryColour: this.kbp2AssColor(colours, parseInt(element[4])),
 					SecondaryColour: this.kbp2AssColor(colours, parseInt(element[2])),
@@ -255,50 +251,43 @@ export default class KBPParser {
 		};
 	}
 
-	/**
-	 * Make a new sentence
-	 * @param {number} id          ID of the sentence
-	 * @param {any[]}  syllables   Syllables list of the sentence
-	 * @param {number} start       Start time of the sentence
-	 * @param {number} end         End time of the sentence
-	 * @param {number} vpos        Vertical position to draw sentence
-	 * @param {number} hpos        Horizontal position to draw sentence
-	 * @param {number} alignment   Text alignment of sentence
-	 */
-	private makeSentence(id: number, syllables: any[], start: number, end: number, currentStyle: string, vpos: number, hpos: number, alignment: number) {
-		var sentence: any = {
-			id: id,
-			start: syllables[0].start,
-			end: syllables[syllables.length - 1].end,
-			currentStyle: currentStyle,
-			vpos: vpos,
-			hpos: hpos,
-			alignment: alignment
-		};
-
-		// Insert sentence syllables as objects or as a string
-		if (this.config['syllable-precision']) {
-			sentence.syllables = syllables;
-		} else {
-			sentence.text = '';
-			for (var j = 0; j < syllables.length; j++) {
-				sentence.text += syllables[j].text;
-			}
-		}
-
-		// Add the start of the sentence if it was present on the last "sentence end" line
-		if (start != null) {
-			sentence.start = start;
-		}
-
-		// Add the end of the sentence if any
-		if (end != null) {
-			sentence.end = end;
-		}
-
-		// Set the duration with start and end
-		sentence.duration = sentence.end - sentence.start;
-
-		return sentence;
-	}
+  /**
+   * Make a new sentence
+   * @param {number} id          ID of the sentence
+   * @param {ISyllable[]}  syllables   Syllables list of the sentence
+   * @param {number} start       Start time of the sentence
+   * @param {number} end         End time of the sentence
+   * @param {number} vpos        Vertical position to draw sentence
+   * @param {number} hpos        Horizontal position to draw sentence
+   * @param {number} alignment   Text alignment of sentence
+   */
+  private makeSentence(
+    id: number,
+    syllables: ISyllable[],
+    start: number,
+    end: number,
+    currentStyle: string,
+    vpos: number,
+    hpos: number,
+    alignment: number
+  ): ISentence {
+    start = start ?? syllables[0].start;
+    end = end ?? syllables[syllables.length - 1].end;
+    const duration = end - start;
+    return {
+      id,
+      start,
+      end,
+      duration,
+      currentStyle,
+      vpos,
+      hpos,
+      alignment,
+      // Insert sentence syllables as objects or as a string
+      syllables: this.config["syllable-precision"] ? syllables : undefined,
+      text: this.config["syllable-precision"]
+        ? ""
+        : syllables.map(s => s.text).join(""),
+    };
+  }
 }

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -40,7 +40,7 @@ export default class KBPParser {
 	 */
 	parse(file: string) {
 
-		// Lyric match regex like ZA/            592/622/0
+		// Lyric match regex like ZA/						592/622/0
 		let regex = /(.*)\/ *([0-9]+)\/([0-9]+)\/([0-9]+)/g;
 
 		if (file.match(regex).length === 0) {
@@ -58,20 +58,20 @@ export default class KBPParser {
 		let colours = null;			// list of colours
 		let currentStyle: string = null;	// Current style
 
-    // Below are defaults from KBS, they should get replaced by the Margins config line
-    let leftMargin = 2;
-    let rightMargin = 2;
-    let topMargin = 7 + (this.config.border ? 12 : 0); // margin from KBS plus CDG top border
-    let lineSpacing = 12 + 19; // the effective line spacing seems to add 19 pixels to the value set in KBS
+		// Below are defaults from KBS, they should get replaced by the Margins config line
+		let leftMargin = 2;
+		let rightMargin = 2;
+		let topMargin = 7 + (this.config.border ? 12 : 0); // margin from KBS plus CDG top border
+		let lineSpacing = 12 + 19; // the effective line spacing seems to add 19 pixels to the value set in KBS
 
-    const totalWidth = this.config.border ? 300 : 288;
-    
-    // not set until a page starts
-    let currentPos = null;
-    let currentOffset = null;
-    let horizontalPos = null;
-    let currentAlignment = null;
-    let defaultWipeProgressive = null;
+		const totalWidth = this.config.border ? 300 : 288;
+		
+		// not set until a page starts
+		let currentPos = null;
+		let currentOffset = null;
+		let horizontalPos = null;
+		let currentAlignment = null;
+		let defaultWipeProgressive = null;
 
 		// We split blocks by PAGEV2, and ignore the first one (it is header)
 		let blockcount = 0;
@@ -87,17 +87,17 @@ export default class KBPParser {
 				continue;
 			}
 
-      if (line.match(/^'Margins/)?.length > 0) {
-        i++;
-        [leftMargin, rightMargin, topMargin, lineSpacing] = lines[i].trim().split(',').map(x => parseInt(x));
-        topMargin += (this.config.border ? 12 : 0);
-        lineSpacing += 19;
-      }
+			if (line.match(/^'Margins/)?.length > 0) {
+				i++;
+				[leftMargin, rightMargin, topMargin, lineSpacing] = lines[i].trim().split(',').map(x => parseInt(x));
+				topMargin += (this.config.border ? 12 : 0);
+				lineSpacing += 19;
+			}
 
-      if (line.match(/^'Other/)?.length > 0) {
-        i++;
-        defaultWipeProgressive = (lines[i].trim().split(',')[1] == '5' ? false : true);
-      }
+			if (line.match(/^'Other/)?.length > 0) {
+				i++;
+				defaultWipeProgressive = (lines[i].trim().split(',')[1] == '5' ? false : true);
+			}
 
 			if (line.match(/^'Palette Colours/)?.length > 0) {
 				i++;
@@ -147,18 +147,18 @@ export default class KBPParser {
 				continue;
 			}
 
-      // TODO: fixed text (lowercase style)
-      // TODO: rotation
-      // TODO: transitions?
+			// TODO: fixed text (lowercase style)
+			// TODO: rotation
+			// TODO: transitions?
 			if (line.match(/[LCR]\/[A-Za-z]/g)?.length > 0) {
 				let element = line.split('/');
 				currentPos += lineSpacing;
-        currentOffset = parseInt(element[5]);
-        currentAlignment = this.getAlignement(element[0]);
-        horizontalPos = (currentAlignment - 7) * totalWidth / 2 + parseInt(element[4]) +
-                        (8 - currentAlignment) * (
-                          (currentAlignment == 7 ? leftMargin : rightMargin) + 
-                          (this.config.border ? 6 : 0));
+				currentOffset = parseInt(element[5]);
+				currentAlignment = this.getAlignement(element[0]);
+				horizontalPos = (currentAlignment - 7) * totalWidth / 2 + parseInt(element[4]) +
+												(8 - currentAlignment) * (
+													(currentAlignment == 7 ? leftMargin : rightMargin) + 
+													(this.config.border ? 6 : 0));
 				if (element[2] !== '0' && element[3] !== '0') {
 					this.styles[element[1].toUpperCase().charCodeAt(0) - 65].Alignment = currentAlignment;
 					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65].Name;
@@ -211,12 +211,12 @@ export default class KBPParser {
 				syllable.end = Math.floor(parseInt(matches[2].trim()) * 10);
 				syllable.duration = syllable.end - syllable.start;
 
-        let wipeType = parseInt(matches[3].trim());
-        if(wipeType == 0) {
-          syllable.wipeProgressive = defaultWipeProgressive;
-        } else {
-          syllable.wipeProgressive = (wipeType == 5 ? false : true);
-        }
+				let wipeType = parseInt(matches[3].trim());
+				if(wipeType == 0) {
+					syllable.wipeProgressive = defaultWipeProgressive;
+				} else {
+					syllable.wipeProgressive = (wipeType == 5 ? false : true);
+				}
 
 
 				if (syllable.start !== 0 || syllable.end !== 0) {
@@ -233,13 +233,13 @@ export default class KBPParser {
 
 	/**
 	 * Make a new sentence
-	 * @param {number} id          ID of the sentence
-	 * @param {any[]}  syllables   Syllables list of the sentence
-	 * @param {number} start       Start time of the sentence
-	 * @param {number} end         End time of the sentence
-	 * @param {number} vpos        Vertical position to draw sentence
-	 * @param {number} hpos        Horizontal position to draw sentence
-	 * @param {number} alignment   Text alignment of sentence
+   * @param {number} id          ID of the sentence
+   * @param {any[]}  syllables   Syllables list of the sentence
+   * @param {number} start       Start time of the sentence
+   * @param {number} end         End time of the sentence
+   * @param {number} vpos        Vertical position to draw sentence
+   * @param {number} hpos        Horizontal position to draw sentence
+   * @param {number} alignment   Text alignment of sentence
 	 */
 	private makeSentence(id: number, syllables: any[], start: number, end: number, currentStyle: string, vpos: number, hpos: number, alignment: number) {
 		var sentence: any = {
@@ -247,9 +247,9 @@ export default class KBPParser {
 			start: syllables[0].start,
 			end: syllables[syllables.length - 1].end,
 			currentStyle: currentStyle,
-      vpos: vpos,
-      hpos: hpos,
-      alignment: alignment
+			vpos: vpos,
+			hpos: hpos,
+			alignment: alignment
 		};
 
 		// Insert sentence syllables as objects or as a string

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,17 +1,17 @@
 interface IConfig {
-	'full-mode'?: boolean;
-	'syllable-precision'?: boolean;
-	'wipe'?: boolean;
-	'position'?: boolean;
-	'border'?: boolean;
-	'cdg'?: boolean;
-	'minimum-progression-duration'?: number;
-	'dialogueScript'?: string;
-	'width'?: number;
-	'transparency'?: boolean;
-	'offset'?: number;
-	'display'?: number;
-	'remove'?: number;
+	"full-mode"?: boolean;
+	"syllable-precision"?: boolean;
+	"wipe"?: boolean;
+	"position"?: boolean;
+	"border"?: boolean;
+	"cdg"?: boolean;
+	"minimum-progression-duration"?: number;
+	"dialogueScript"?: string;
+	"width"?: number;
+	"transparency"?: boolean;
+	"offset"?: number;
+	"display"?: number;
+	"remove"?: number;
 }
 
 interface IStyle {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-export interface ConverterConfig {
+interface IConfig {
 	'full-mode'?: boolean;
 	'syllable-precision'?: boolean;
 	'wipe'?: boolean;
@@ -9,9 +9,9 @@ export interface ConverterConfig {
   'dialogueScript'?: string;
 	'transparency'?: boolean;
   'offset'?: number;
-}
-
-interface StyleElement {
+  }
+  
+  interface IStyle {
 	Name: string;
 	PrimaryColour: string;
 	SecondaryColour: string;
@@ -27,7 +27,80 @@ interface StyleElement {
 	Outline?: number;
 	Shadow?: number;
 	Alignment?: number;
-}
-
-export function convertToASS(time: string, options: ConverterConfig): string
-
+	ScaleX?: number;
+	ScaleY?: number;
+	Spacing?: number;
+	Angle?: number;
+	BorderStyle?: number;
+	MarginL?: number;
+	MarginR?: number;
+	MarginV?: number;
+  }
+  interface IStyleKV {
+	key: "Style";
+	value: IStyle;
+  }
+  interface IStyles {
+	section: string;
+	body: Array<{ key: "Format"; value: Array<keyof IStyle> } | IStyleKV>;
+  }
+  interface IDialogue {
+	Layer: string;
+	Start: string;
+	End: string;
+	Style: string;
+	Name: string;
+	MarginL: string;
+	MarginR: string;
+	MarginV: string;
+	Effect: string;
+	Text: string;
+  }
+  interface IDialogueKV<T> {
+	key: T;
+	value: IDialogue;
+  }
+  interface IFormatKV {
+	key: "Format";
+	value: Array<keyof IDialogue>;
+  }
+  
+  // ? same as sentence ?
+  interface ISyllable {
+	text: string;
+	start: number;
+	end: number;
+	duration: number;
+	wipeProgressive: boolean;
+  }
+  interface ISentence {
+	id: number;
+	syllables: ISyllable[];
+	start: number;
+	end: number;
+	currentStyle: string;
+	vpos: number;
+	hpos: number;
+	alignment: number;
+	text: string;
+	duration: number;
+  }
+  
+  interface IScriptInfo {
+	section: string;
+	body: {
+	  type?: string;
+	  value: string | number;
+	  key?: string;
+	}[];
+  }
+  
+  interface IEvents {
+	section: "Events";
+	body: Array<IFormatKV | IDialogueKV<"Dialogue"> | IDialogueKV<"Comment">>;
+  }
+  
+  type TSection = IScriptInfo | IStyles | IEvents;
+  
+  export function convertToASS(time: string, options: IConfig): string;
+  

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,6 +38,7 @@ interface IConfig {
 	MarginL?: number;
 	MarginR?: number;
 	MarginV?: number;
+	AllCaps?: boolean; // Virtual attribute, used during conversion, not part of ass file
   }
   interface IStyleKV {
 	key: "Style";

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -69,7 +69,6 @@ interface IConfig {
 	value: Array<keyof IDialogue>;
   }
   
-  // ? same as sentence ?
   interface ISyllable {
 	text: string;
 	start: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,11 @@
-export interface SyllabesConfig {
-	syllable_precision?: boolean;
-	minimum_progression_duration?: number;
+export interface ConverterConfig {
+	'full-mode'?: boolean;
+	'syllable-precision'?: boolean;
+	'wipe'?: boolean;
+	'position'?: boolean;
+	'border'?: boolean;
+	'cdg'?: boolean;
+	'minimum-progression-duration'?: number;
 }
 
 interface StyleElement {
@@ -21,5 +26,5 @@ interface StyleElement {
 	Alignment?: number;
 }
 
-export function convertToASS(time: string, options: SyllabesConfig): string
+export function convertToASS(time: string, options: ConverterConfig): string
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ export interface ConverterConfig {
 	'border'?: boolean;
 	'cdg'?: boolean;
 	'minimum-progression-duration'?: number;
+  'dialogueScript'?: string;
 }
 
 interface StyleElement {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,7 +10,7 @@ interface StyleElement {
 	OutlineColour: string;
 	BackColour: string;
 	Fontname?: string;
-	Fontsize?: string;
+	Fontsize?: number;
 	Bold?: number;
 	Italic?: number;
 	Underline?: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -78,7 +78,7 @@ interface IConfig {
 	syllables: ISyllable[];
 	start: number;
 	end: number;
-	currentStyle: string;
+	styleName: string;
 	vpos: number;
 	hpos: number;
 	alignment: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,9 +12,9 @@ interface IConfig {
 	'offset'?: number;
 	'display'?: number;
 	'remove'?: number;
-  }
-  
-  interface IStyle {
+}
+
+interface IStyle {
 	Name: string;
 	PrimaryColour: string;
 	SecondaryColour: string;
@@ -39,16 +39,16 @@ interface IConfig {
 	MarginR?: number;
 	MarginV?: number;
 	AllCaps?: boolean; // Virtual attribute, used during conversion, not part of ass file
-  }
-  interface IStyleKV {
+}
+interface IStyleKV {
 	key: "Style";
 	value: IStyle;
-  }
-  interface IStyles {
+}
+interface IStyles {
 	section: string;
 	body: Array<{ key: "Format"; value: Array<keyof IStyle> } | IStyleKV>;
-  }
-  interface IDialogue {
+}
+interface IDialogue {
 	Layer: string;
 	Start: string;
 	End: string;
@@ -59,24 +59,24 @@ interface IConfig {
 	MarginV: string;
 	Effect: string;
 	Text: string;
-  }
-  interface IDialogueKV<T> {
+}
+interface IDialogueKV<T> {
 	key: T;
 	value: IDialogue;
-  }
-  interface IFormatKV {
+}
+interface IFormatKV {
 	key: "Format";
 	value: Array<keyof IDialogue>;
-  }
-  
-  interface ISyllable {
+}
+
+interface ISyllable {
 	text: string;
 	start: number;
 	end: number;
 	duration: number;
 	wipeProgressive: boolean;
-  }
-  interface ISentence {
+}
+interface ISentence {
 	id: number;
 	syllables: ISyllable[];
 	start: number;
@@ -87,24 +87,23 @@ interface IConfig {
 	alignment: number;
 	text: string;
 	duration: number;
-    rotation: number;
-  }
-  
-  interface IScriptInfo {
+	rotation: number;
+}
+
+interface IScriptInfo {
 	section: string;
 	body: {
-	  type?: string;
-	  value: string | number;
-	  key?: string;
+		type?: string;
+		value: string | number;
+		key?: string;
 	}[];
-  }
-  
-  interface IEvents {
+}
+
+interface IEvents {
 	section: "Events";
 	body: Array<IFormatKV | IDialogueKV<"Dialogue"> | IDialogueKV<"Comment">>;
-  }
-  
-  type TSection = IScriptInfo | IStyles | IEvents;
-  
-  export function convertToASS(time: string, options: IConfig): string;
-  
+}
+
+type TSection = IScriptInfo | IStyles | IEvents;
+
+export function convertToASS(time: string, options: IConfig): string;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,7 @@ export interface ConverterConfig {
 	'minimum-progression-duration'?: number;
   'dialogueScript'?: string;
 	'transparency'?: boolean;
+  'offset'?: number;
 }
 
 interface StyleElement {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,7 +9,9 @@ interface IConfig {
 	'dialogueScript'?: string;
 	'width'?: number;
 	'transparency'?: boolean;
-  'offset'?: number;
+	'offset'?: number;
+	'display'?: number;
+	'remove'?: number;
   }
   
   interface IStyle {
@@ -19,7 +21,7 @@ interface IConfig {
 	OutlineColour: string;
 	BackColour: string;
 	Fontname?: string;
-	Fontsize?: number;
+	Fontsize?: string;
 	Bold?: number;
 	Italic?: number;
 	Underline?: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,6 +7,7 @@ export interface ConverterConfig {
 	'cdg'?: boolean;
 	'minimum-progression-duration'?: number;
   'dialogueScript'?: string;
+	'transparency'?: boolean;
 }
 
 interface StyleElement {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,6 +7,7 @@ export interface ConverterConfig {
 	'cdg'?: boolean;
 	'minimum-progression-duration'?: number;
   'dialogueScript'?: string;
+  'width'?: number;
 }
 
 interface StyleElement {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,14 +9,15 @@ export function msToAss(ms: number): string {
 	const mil = date.getUTCMilliseconds();
 	const milStr = `${mil}`.padStart(3, "0");
 	return `${hourStr}:${minStr}:${secStr}.${milStr.substr(0, 2)}`;
-  }
-  
-  export function clone<T>(a: T): T {
+}
+
+export function clone<T>(a: T): T {
 	return JSON.parse(JSON.stringify(a));
-  }
-  export function pickValues<K extends string | number | symbol, V>(
+}
+
+export function pickValues<K extends string | number | symbol, V>(
 	obj: Record<K, V>,
 	keys: K | K[]
-  ): V[] {
-	return Array.isArray(keys) ? keys.map(key => obj[key]) : [obj[keys]];
-  }
+	): V[] {
+		return Array.isArray(keys) ? keys.map(key => obj[key]) : [obj[keys]];
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,30 +1,22 @@
-import {promisify} from 'util';
-import {exists, readFile, writeFile} from 'fs';
-
-
-const passThroughFunction = (fn: any, args: any) => {
-	if(!Array.isArray(args)) args = [args];
-	return promisify(fn)(...args);
-};
-
-export const asyncExists = (file: string) => passThroughFunction(exists, file);
-export const asyncReadFile = (...args: any) => passThroughFunction(readFile, args);
-export const asyncWriteFile = (...args: any) => passThroughFunction(writeFile, args);
-
 export function msToAss(ms: number): string {
 	const date = new Date(ms);
 	const hour = date.getUTCHours();
-	const hourStr = `${hour}`.padStart(1, '0');
-	const min  = date.getUTCMinutes();
-	const minStr = `${min}`.padStart(2, '0');
-	const sec  = date.getUTCSeconds();
-	const secStr = `${sec}`.padStart(2, '0');
-	const mil  = date.getUTCMilliseconds();
-	const milStr = `${mil}`.padStart(3, '0');
+	const hourStr = `${hour}`.padStart(1, "0");
+	const min = date.getUTCMinutes();
+	const minStr = `${min}`.padStart(2, "0");
+	const sec = date.getUTCSeconds();
+	const secStr = `${sec}`.padStart(2, "0");
+	const mil = date.getUTCMilliseconds();
+	const milStr = `${mil}`.padStart(3, "0");
 	return `${hourStr}:${minStr}:${secStr}.${milStr.substr(0, 2)}`;
-}
-
-
-export function clone(a: any) {
+  }
+  
+  export function clone<T>(a: T): T {
 	return JSON.parse(JSON.stringify(a));
-}
+  }
+  export function pickValues<K extends string | number | symbol, V>(
+	obj: Record<K, V>,
+	keys: K | K[]
+  ): V[] {
+	return Array.isArray(keys) ? keys.map(key => obj[key]) : [obj[keys]];
+  }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,6 @@ export function clone<T>(a: T): T {
 export function pickValues<K extends string | number | symbol, V>(
 	obj: Record<K, V>,
 	keys: K | K[]
-	): V[] {
-		return Array.isArray(keys) ? keys.map(key => obj[key]) : [obj[keys]];
+): V[] {
+	return Array.isArray(keys) ? keys.map(key => obj[key]) : [obj[keys]];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@aashutoshrathi/word-wrap@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
+  integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -9,14 +14,26 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eslint/eslintrc@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
-  integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.6.1":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.6.2.tgz#1816b5f6948029c5eaacb0703b850ee0cb37d8f8"
+  integrity sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==
+
+"@eslint/eslintrc@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.1.tgz#18d635e24ad35f7276e8a49d135c7d3ca6a46f93"
+  integrity sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.4.0"
+    espree "^9.6.0"
     globals "^13.19.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
@@ -24,10 +41,15 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@humanwhocodes/config-array@^0.11.8":
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
-  integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
+"@eslint/js@^8.46.0":
+  version "8.46.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.46.0.tgz#3f7802972e8b6fe3f88ed1aabc74ec596c456db6"
+  integrity sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==
+
+"@humanwhocodes/config-array@^0.11.10":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
+  integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
@@ -44,14 +66,14 @@
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@jridgewell/resolve-uri@^3.0.3":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
 "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -98,14 +120,14 @@
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/node16@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
-  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
 "@types/node@^17.0.31":
   version "17.0.45"
@@ -113,92 +135,92 @@
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
 "@types/semver@^7.3.12":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@typescript-eslint/eslint-plugin@^5.22.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.50.0.tgz#fb48c31cadc853ffc1dc35373f56b5e2a8908fe9"
-  integrity sha512-vwksQWSFZiUhgq3Kv7o1Jcj0DUNylwnIlGvKvLLYsq8pAWha6/WCnXUeaSoNNha/K7QSf2+jvmkxggC1u3pIwQ==
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
+  integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.50.0"
-    "@typescript-eslint/type-utils" "5.50.0"
-    "@typescript-eslint/utils" "5.50.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/type-utils" "5.62.0"
+    "@typescript-eslint/utils" "5.62.0"
     debug "^4.3.4"
-    grapheme-splitter "^1.0.4"
+    graphemer "^1.4.0"
     ignore "^5.2.0"
     natural-compare-lite "^1.4.0"
-    regexpp "^3.2.0"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.22.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.50.0.tgz#a33f44b2cc83d1b7176ec854fbecd55605b0b032"
-  integrity sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
+  integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.50.0"
-    "@typescript-eslint/types" "5.50.0"
-    "@typescript-eslint/typescript-estree" "5.50.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.50.0.tgz#90b8a3b337ad2c52bbfe4eac38f9164614e40584"
-  integrity sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==
+"@typescript-eslint/scope-manager@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
+  integrity sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==
   dependencies:
-    "@typescript-eslint/types" "5.50.0"
-    "@typescript-eslint/visitor-keys" "5.50.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/type-utils@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.50.0.tgz#509d5cc9728d520008f7157b116a42c5460e7341"
-  integrity sha512-dcnXfZ6OGrNCO7E5UY/i0ktHb7Yx1fV6fnQGGrlnfDhilcs6n19eIRcvLBqx6OQkrPaFlDPk3OJ0WlzQfrV0bQ==
+"@typescript-eslint/type-utils@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz#286f0389c41681376cdad96b309cedd17d70346a"
+  integrity sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.50.0"
-    "@typescript-eslint/utils" "5.50.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    "@typescript-eslint/utils" "5.62.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.50.0.tgz#c461d3671a6bec6c2f41f38ed60bd87aa8a30093"
-  integrity sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w==
+"@typescript-eslint/types@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
+  integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
-"@typescript-eslint/typescript-estree@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.50.0.tgz#0b9b82975bdfa40db9a81fdabc7f93396867ea97"
-  integrity sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==
+"@typescript-eslint/typescript-estree@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
+  integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
   dependencies:
-    "@typescript-eslint/types" "5.50.0"
-    "@typescript-eslint/visitor-keys" "5.50.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.50.0.tgz#807105f5ffb860644d30d201eefad7017b020816"
-  integrity sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==
+"@typescript-eslint/utils@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
+  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
   dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.50.0"
-    "@typescript-eslint/types" "5.50.0"
-    "@typescript-eslint/typescript-estree" "5.50.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
     eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.50.0.tgz#b752ffc143841f3d7bc57d6dd01ac5c40f8c4903"
-  integrity sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==
+"@typescript-eslint/visitor-keys@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
+  integrity sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==
   dependencies:
-    "@typescript-eslint/types" "5.50.0"
+    "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
 acorn-jsx@^5.3.2:
@@ -211,12 +233,12 @@ acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.8.0:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
-  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
+acorn@^8.4.1, acorn@^8.9.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
-ajv@^6.10.0, ajv@^6.12.4:
+ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -252,13 +274,6 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-ass-stringify@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ass-stringify/-/ass-stringify-0.1.3.tgz#33def35e9572682f1333eb1ae1ece192de5312b9"
-  integrity sha512-8kdRn8odBRFcDbcAGCIDR57zOcNECHyEDjCKzN20b2TzFsU2S4m+1GiI4vizR11dmHPdN65Xa11X4iCcC6kNMg==
-  dependencies:
-    pick-values "^1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -387,89 +402,75 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
-  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
-
-eslint-visitor-keys@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
-  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz#8c2095440eca8c933bedcadf16fefa44dbe9ba5f"
+  integrity sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==
 
 eslint@^8.14.0:
-  version "8.33.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.33.0.tgz#02f110f32998cb598c6461f24f4d306e41ca33d7"
-  integrity sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==
+  version "8.46.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.46.0.tgz#a06a0ff6974e53e643acc42d1dcf2e7f797b3552"
+  integrity sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==
   dependencies:
-    "@eslint/eslintrc" "^1.4.1"
-    "@humanwhocodes/config-array" "^0.11.8"
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.1"
+    "@eslint/js" "^8.46.0"
+    "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
+    ajv "^6.12.4"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.1"
-    eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.3.0"
-    espree "^9.4.0"
-    esquery "^1.4.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.2"
+    espree "^9.6.1"
+    esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
     find-up "^5.0.0"
     glob-parent "^6.0.2"
     globals "^13.19.0"
-    grapheme-splitter "^1.0.4"
+    graphemer "^1.4.0"
     ignore "^5.2.0"
-    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
     is-path-inside "^3.0.3"
-    js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
     minimatch "^3.1.2"
     natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    regexpp "^3.2.0"
+    optionator "^0.9.3"
     strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
-espree@^9.4.0:
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
-  integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
+espree@^9.6.0, espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
-    acorn "^8.8.0"
+    acorn "^8.9.0"
     acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.3.0"
+    eslint-visitor-keys "^3.4.1"
 
-esquery@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
-  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+esquery@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -501,9 +502,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.9:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -618,10 +619,10 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-grapheme-splitter@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
-  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -633,7 +634,7 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -690,11 +691,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
-js-sdsl@^4.1.4:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
-  integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
 js-yaml@^4.1.0:
   version "4.1.0"
@@ -787,17 +783,17 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+optionator@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
+  integrity sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==
   dependencies:
+    "@aashutoshrathi/word-wrap" "^1.2.3"
     deep-is "^0.1.3"
     fast-levenshtein "^2.0.6"
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
-    word-wrap "^1.2.3"
 
 p-limit@^3.0.2:
   version "3.1.0"
@@ -840,11 +836,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pick-values@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pick-values/-/pick-values-1.0.1.tgz#67b2d7734e593eb5ba082a54a0477560e374254d"
-  integrity sha512-Xr86yRoJqntrYyutz4xTU+N3+dKZO4ki0LIO4LGKQDu346Ka4tkv1fSPjOisLPfihzN6+TX6nxj90dkxEo8ikA==
-
 picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -864,11 +855,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-regexpp@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -900,9 +886,9 @@ run-parallel@^1.1.9:
     queue-microtask "^1.2.2"
 
 semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -939,7 +925,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -1030,11 +1016,6 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -1065,9 +1046,9 @@ yargs-parser@^21.1.1:
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^17.6.2:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,204 +2,221 @@
 # yarn lockfile v1
 
 
-"@cspotcode/source-map-consumer@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
-  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
-
-"@cspotcode/source-map-support@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
-  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
-    "@cspotcode/source-map-consumer" "0.8.0"
+    "@jridgewell/trace-mapping" "0.3.9"
 
-"@eslint/eslintrc@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.2.tgz#4989b9e8c0216747ee7cca314ae73791bb281aae"
-  integrity sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==
+"@eslint/eslintrc@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
+  integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.3.1"
-    globals "^13.9.0"
+    espree "^9.4.0"
+    globals "^13.19.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
     js-yaml "^4.1.0"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@humanwhocodes/config-array@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
-  integrity sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
+"@humanwhocodes/config-array@^0.11.8":
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
+  integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
-    minimatch "^3.0.4"
+    minimatch "^3.0.5"
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@nodelib/fs.scandir@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
-  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
   dependencies:
-    "@nodelib/fs.stat" "2.0.4"
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
-  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
-  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.4"
+    "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
 "@tsconfig/node10@^1.0.7":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
-  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
 
 "@tsconfig/node12@^1.0.7":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
-  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
 "@tsconfig/node14@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
-  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/node16@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
-  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/json-schema@^7.0.9":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
-  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/node@^17.0.31":
-  version "17.0.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.31.tgz#a5bb84ecfa27eec5e1c802c6bbf8139bdb163a5d"
-  integrity sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
 "@typescript-eslint/eslint-plugin@^5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz#7b52a0de2e664044f28b36419210aea4ab619e2a"
-  integrity sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.50.0.tgz#fb48c31cadc853ffc1dc35373f56b5e2a8908fe9"
+  integrity sha512-vwksQWSFZiUhgq3Kv7o1Jcj0DUNylwnIlGvKvLLYsq8pAWha6/WCnXUeaSoNNha/K7QSf2+jvmkxggC1u3pIwQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.22.0"
-    "@typescript-eslint/type-utils" "5.22.0"
-    "@typescript-eslint/utils" "5.22.0"
-    debug "^4.3.2"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
+    "@typescript-eslint/scope-manager" "5.50.0"
+    "@typescript-eslint/type-utils" "5.50.0"
+    "@typescript-eslint/utils" "5.50.0"
+    debug "^4.3.4"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
     regexpp "^3.2.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.22.0.tgz#7bedf8784ef0d5d60567c5ba4ce162460e70c178"
-  integrity sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.50.0.tgz#a33f44b2cc83d1b7176ec854fbecd55605b0b032"
+  integrity sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.22.0"
-    "@typescript-eslint/types" "5.22.0"
-    "@typescript-eslint/typescript-estree" "5.22.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.50.0"
+    "@typescript-eslint/types" "5.50.0"
+    "@typescript-eslint/typescript-estree" "5.50.0"
+    debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz#590865f244ebe6e46dc3e9cab7976fc2afa8af24"
-  integrity sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==
+"@typescript-eslint/scope-manager@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.50.0.tgz#90b8a3b337ad2c52bbfe4eac38f9164614e40584"
+  integrity sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==
   dependencies:
-    "@typescript-eslint/types" "5.22.0"
-    "@typescript-eslint/visitor-keys" "5.22.0"
+    "@typescript-eslint/types" "5.50.0"
+    "@typescript-eslint/visitor-keys" "5.50.0"
 
-"@typescript-eslint/type-utils@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz#0c0e93b34210e334fbe1bcb7250c470f4a537c19"
-  integrity sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==
+"@typescript-eslint/type-utils@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.50.0.tgz#509d5cc9728d520008f7157b116a42c5460e7341"
+  integrity sha512-dcnXfZ6OGrNCO7E5UY/i0ktHb7Yx1fV6fnQGGrlnfDhilcs6n19eIRcvLBqx6OQkrPaFlDPk3OJ0WlzQfrV0bQ==
   dependencies:
-    "@typescript-eslint/utils" "5.22.0"
-    debug "^4.3.2"
+    "@typescript-eslint/typescript-estree" "5.50.0"
+    "@typescript-eslint/utils" "5.50.0"
+    debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.22.0.tgz#50a4266e457a5d4c4b87ac31903b28b06b2c3ed0"
-  integrity sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==
+"@typescript-eslint/types@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.50.0.tgz#c461d3671a6bec6c2f41f38ed60bd87aa8a30093"
+  integrity sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w==
 
-"@typescript-eslint/typescript-estree@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz#e2116fd644c3e2fda7f4395158cddd38c0c6df97"
-  integrity sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==
+"@typescript-eslint/typescript-estree@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.50.0.tgz#0b9b82975bdfa40db9a81fdabc7f93396867ea97"
+  integrity sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==
   dependencies:
-    "@typescript-eslint/types" "5.22.0"
-    "@typescript-eslint/visitor-keys" "5.22.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
+    "@typescript-eslint/types" "5.50.0"
+    "@typescript-eslint/visitor-keys" "5.50.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.22.0.tgz#1f2c4897e2cf7e44443c848a13c60407861babd8"
-  integrity sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==
+"@typescript-eslint/utils@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.50.0.tgz#807105f5ffb860644d30d201eefad7017b020816"
+  integrity sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.22.0"
-    "@typescript-eslint/types" "5.22.0"
-    "@typescript-eslint/typescript-estree" "5.22.0"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.50.0"
+    "@typescript-eslint/types" "5.50.0"
+    "@typescript-eslint/typescript-estree" "5.50.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
+    semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz#f49c0ce406944ffa331a1cfabeed451ea4d0909c"
-  integrity sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==
+"@typescript-eslint/visitor-keys@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.50.0.tgz#b752ffc143841f3d7bc57d6dd01ac5c40f8c4903"
+  integrity sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==
   dependencies:
-    "@typescript-eslint/types" "5.22.0"
-    eslint-visitor-keys "^3.0.0"
+    "@typescript-eslint/types" "5.50.0"
+    eslint-visitor-keys "^3.3.0"
 
-acorn-jsx@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
-  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
-  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+acorn@^8.4.1, acorn@^8.8.0:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
-ajv@^6.10.0:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
-  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.4:
+ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -214,7 +231,7 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -222,9 +239,9 @@ ansi-styles@^4.1.0:
     color-convert "^2.0.1"
 
 arg@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.1.tgz#485f8e7c390ce4c5f78257dbea80d4be11feda4c"
-  integrity sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -239,14 +256,14 @@ array-union@^2.1.0:
 ass-stringify@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ass-stringify/-/ass-stringify-0.1.3.tgz#33def35e9572682f1333eb1ae1ece192de5312b9"
-  integrity sha1-M97zXpVyaC8TM+sa4ezhkt5TErk=
+  integrity sha512-8kdRn8odBRFcDbcAGCIDR57zOcNECHyEDjCKzN20b2TzFsU2S4m+1GiI4vizR11dmHPdN65Xa11X4iCcC6kNMg==
   dependencies:
     pick-values "^1.0.0"
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -256,7 +273,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1:
+braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -269,12 +286,21 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 chalk@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -291,7 +317,7 @@ color-name@~1.1.4:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -307,29 +333,22 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.1.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.3.2:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
 deep-is@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 diff@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
-  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -344,6 +363,16 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -378,23 +407,20 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
-  integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
-
 eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.14.0:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.14.0.tgz#62741f159d9eb4a79695b28ec4989fcdec623239"
-  integrity sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==
+  version "8.33.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.33.0.tgz#02f110f32998cb598c6461f24f4d306e41ca33d7"
+  integrity sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==
   dependencies:
-    "@eslint/eslintrc" "^1.2.2"
-    "@humanwhocodes/config-array" "^0.9.2"
+    "@eslint/eslintrc" "^1.4.1"
+    "@humanwhocodes/config-array" "^0.11.8"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -404,38 +430,40 @@ eslint@^8.14.0:
     eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
     eslint-visitor-keys "^3.3.0"
-    espree "^9.3.1"
+    espree "^9.4.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^6.0.1"
-    globals "^13.6.0"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
     regexpp "^3.2.0"
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
 
-espree@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.1.tgz#8793b4bc27ea4c778c19908e0719e7b8f4115bcd"
-  integrity sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==
+espree@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
+  integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
   dependencies:
-    acorn "^8.7.0"
-    acorn-jsx "^5.3.1"
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
 esquery@^1.4.0:
@@ -458,19 +486,14 @@ estraverse@^4.1.1:
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -478,9 +501,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.9:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -489,19 +512,19 @@ fast-glob@^3.2.9:
     micromatch "^4.0.4"
 
 fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
-  integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
 
@@ -519,6 +542,14 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -528,19 +559,19 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
-  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -549,7 +580,7 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -557,32 +588,25 @@ glob-parent@^6.0.1:
     is-glob "^4.0.3"
 
 glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^13.6.0:
-  version "13.8.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
-  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
+globals@^13.19.0:
+  version "13.20.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
+  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
   dependencies:
     type-fest "^0.20.2"
 
-globals@^13.9.0:
-  version "13.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
-  integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
-  dependencies:
-    type-fest "^0.20.2"
-
-globby@^11.0.4:
+globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -594,25 +618,22 @@ globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-ignore@^5.1.8, ignore@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
-  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+ignore@^5.2.0:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-import-fresh@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
-  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -623,12 +644,12 @@ import-fresh@^3.2.1:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -641,16 +662,14 @@ inherits@2:
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
-  dependencies:
-    is-extglob "^2.1.1"
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -662,10 +681,20 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+js-sdsl@^4.1.4:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
+  integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
 js-yaml@^4.1.0:
   version "4.1.0"
@@ -682,7 +711,7 @@ json-schema-traverse@^0.4.1:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -691,6 +720,13 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -705,9 +741,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 make-error@^1.1.1:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
-  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -715,17 +751,17 @@ merge2@^1.3.0, merge2@^1.4.1:
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromatch@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
-  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
-    braces "^3.0.1"
-    picomatch "^2.2.3"
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
-minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -734,15 +770,20 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
@@ -758,6 +799,20 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -765,10 +820,15 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.1.0:
   version "3.1.1"
@@ -783,12 +843,12 @@ path-type@^4.0.0:
 pick-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pick-values/-/pick-values-1.0.1.tgz#67b2d7734e593eb5ba082a54a0477560e374254d"
-  integrity sha1-Z7LXc05ZPrW6CCpUoEd1YON0JU0=
+  integrity sha512-Xr86yRoJqntrYyutz4xTU+N3+dKZO4ki0LIO4LGKQDu346Ka4tkv1fSPjOisLPfihzN6+TX6nxj90dkxEo8ikA==
 
-picomatch@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
-  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -796,9 +856,9 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -809,6 +869,11 @@ regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -834,10 +899,10 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+semver@^7.3.7:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -858,7 +923,16 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-strip-ansi@^6.0.1:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -880,7 +954,7 @@ supports-color@^7.1.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -890,11 +964,11 @@ to-regex-range@^5.0.1:
     is-number "^7.0.0"
 
 ts-node@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
-  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
-    "@cspotcode/source-map-support" "0.7.0"
+    "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"
     "@tsconfig/node14" "^1.0.0"
@@ -905,13 +979,13 @@ ts-node@^10.7.0:
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.0"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 tslib@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -932,27 +1006,22 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@~4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
-v8-compile-cache-lib@^3.0.0:
+v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
-
-v8-compile-cache@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
-  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
 which@^2.0.1:
   version "2.0.2"
@@ -966,17 +1035,54 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.6.2:
+  version "17.6.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
+  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
Sorry it's been so long, but I think this is finally mergeable. There are a few differences in the default behavior from your original version:

- Gaps are added in if present in the sync (e.g. if there is a 50ms pause between two syllables, it will add a {\k5} before the \kf or \k for the next syllable). With the current version, it will just eat the gap and the line will end too soon.
- Font is scaled up a bit (1.4x) to roughly accommodate the difference between font size (KBS) and line height (ASS). I do want to improve this, at least offering it as a parameter, but haven't gotten to it yet
- Some escaping is added to lyrics from .kbp:
  - "{~}" to "/" - this is how KBS writes "/", because it's a special character in its file format
  - "{}" prepended with "\\" - This is not technically part of the .ass standard, but is supported by libass. It's either we do this, just delete {}. or allow arbitrary .ass code, so this seemed like the best option to me. Maybe it should be made configurable too
  - Add a zero-width space between \ and something that would generate an escape sequence to display it literally
  - Space at the beginning of the line changed to "\h"
- If the user has an offset configured in KBS, it will apply it during the conversion (configurable to disable that or use a different offset)
- A couple bugfixes related to styles - invalid style numbers default to style 0, and gaps in styles (e.g. first two styles are present, third is missing, then fourth is present) do not cause problems

Of course, there are also a ton of additional options used by kbp2video users to create YouTube videos. In CLI usage, --full-mode (-f) enables several of these at once.