### PR TITLE
Remove obsolete param, improve parameters and fixed text handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.1.3
+
+Improve fixed text support, change minimum-progression-duration to minimumProgressionDuration, remove syllable-precision
+
+## 1.1.2
+
+Minor fixes for some reason changes
+
 ## 1.1.1
 
 Ensure behavior matches upstream by default where possible (except in the case of bugs)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options are :
 
 ```JS
 {
-  'minimum-progression-duration': number,
+  'minimumProgressionDuration': number,
   'cdg': boolean,
   'wipe': boolean,
   'position': boolean,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Options are :
 
 ```JS
 {
-  'syllable-precision': boolean,
   'minimum-progression-duration': number,
   'cdg': boolean,
   'wipe': boolean,
@@ -65,8 +64,6 @@ Disable any boolean option with --no-[option]
 Options:
       --help                                            Show help                                                                        [boolean]
       --version                                         Show version number                                                              [boolean]
-  -s, --syllable-precision                              Highlight syllables individually instead of combining lines into a single string.
-                                                        Disabling this is not recommended.                               [boolean] [default: true]
   -m, --minimum-progression-duration, --wipe-threshold  Set threshold of syllable display time in milliseconds before using progressive wipe
                                                         effect (implicit default 1000)                                                    [number]
   -f, --full-mode                                       Enable processing of all positional and style information in the KBS project file (-w, -p,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbp2ass",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Convert KBP karaoke files to ASS files",
   "main": "dist/index.js",
   "types": "src/types.d.ts",

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -21,25 +21,20 @@ function generateASSLine(line: ISentence, options: IConfig) {
 	let firstStart = null;
 	let lastSylEnd = null;
 	let gap = null;
-	if(line.syllables) {
-		line.syllables.forEach(syl => {
-			gap =
-				lastSylEnd != null && syl.start - lastSylEnd > 10
-					? `{\\k${(syl.start - lastSylEnd) / 10}}`
-					: "";
-			assLine.push(
-				`${gap}{\\k${getProgressive(syl, options)}${Math.floor(
-					syl.duration / 10
-				)}}${escapeAss(syl.text, firstStart == null)}`
-			);
+	line.syllables.forEach(syl => {
+		gap =
+			lastSylEnd != null && syl.start - lastSylEnd > 10
+				? `{\\k${(syl.start - lastSylEnd) / 10}}`
+				: "";
+		assLine.push(
+			`${gap}{\\k${getProgressive(syl, options)}${Math.floor(
+				syl.duration / 10
+			)}}${escapeAss(syl.text, firstStart == null)}`
+		);
 
-			if (firstStart == null) firstStart = syl.start;
-			lastSylEnd = syl.end;
-		});
-	} else {
-		assLine.push(escapeAss(line.text, true));
-		firstStart=line.end; // Emulate "fixed text" and use the text style rather than the wipe style
-	}
+		if (firstStart == null) firstStart = syl.start;
+		lastSylEnd = syl.end;
+	});
 	const dialogue = clone(ass.defaultDialogue);
 
 	// Comment starts exactly with syllables to allow for retiming
@@ -127,7 +122,7 @@ export function convertToASS(time: string, options: IConfig) {
 	const styles = clone(ass.styles);
 	styles.body = styles.body.concat(
 		kbp.styles.length > 0
-			? kbp.styles.map(style => getStyleAss(style))
+			? [...kbp.styles, ...kbp.fixedStyles].map(style => getStyleAss(style))
 			: [{ ...ass.defaultStyle }]
 	);
 

--- a/src/ass.ts
+++ b/src/ass.ts
@@ -96,7 +96,7 @@ function getProgressive(syl: ISyllable, options: IConfig) {
 	// When duration exceeds the threshold, progressive wiping may be possible
 	if (
 		Math.floor(syl.duration / 10) >
-		Math.floor(options["minimum-progression-duration"] / 10)
+		Math.floor(options.minimumProgressionDuration / 10)
 	) {
 		// If option is set to use wiping setting from the kbp file, do so, otherwise set unconditionally
 		return options.wipe && !syl.wipeProgressive ? "" : "f";

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,15 +72,6 @@ async function mainCLI() {
 		.hide("compat1")
 		.hide("compat2")
 		.options({
-			"syllable-precision": {
-				alias: "s",
-				description: "Highlight syllables individually instead of combining lines into a single string. Disabling this is not recommended.",
-				type: "boolean",
-				default: true,
-				// "nargs: 0" alone doesn't seem to be enough to stop a flag from consuming a parameter next to it
-				requiresArg: false,
-				nargs: 0
-			},
 			"minimum-progression-duration": {
 				alias: ["m", "wipe-threshold"],
 				description: "Set threshold of syllable display time in milliseconds before using progressive wipe effect (implicit default 1000)",
@@ -250,9 +241,9 @@ async function mainCLI() {
 	[argv.display, argv.remove] = displayremoveToDisplayRemove(argv.displayremove);
 	delete argv.displayremove;
 
-	// Remap keys to be more javascript-friendly
-	argv = (({"syllable-precision": syllablePrecision, "minimum-progression-duration": minimumProgressionDuration, ...rest}) =>
-		({syllablePrecision, minimumProgressionDuration, ...rest}))(argv);
+	// Remap key to be more javascript-friendly
+	argv = (({"minimum-progression-duration": minimumProgressionDuration, ...rest}) =>
+		({minimumProgressionDuration, ...rest}))(argv);
 
 	// This should be updated to work on Windows, but it would involve some extra
 	// work because even though readFile can take a file descriptor, it doesn't seem

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function mainCLI() {
 	// of assigning a variable name to the instance so it can be referenced
 	const yargsInstance = yargs(hideBin(process.argv));
 
-	const argv = yargsInstance
+	let argv = yargsInstance
 		.scriptName("kbp2ass")
 		.parserConfiguration({
 			"camel-case-expansion": false,
@@ -249,6 +249,10 @@ async function mainCLI() {
 
 	[argv.display, argv.remove] = displayremoveToDisplayRemove(argv.displayremove);
 	delete argv.displayremove;
+
+    // Remap keys to be more javascript-friendly
+    argv = (({"syllable-precision": syllablePrecision, "minimum-progression-duration": minimumProgressionDuration, ...rest}) =>
+        ({syllablePrecision, minimumProgressionDuration, ...rest}))(argv)
 
 	// This should be updated to work on Windows, but it would involve some extra
 	// work because even though readFile can take a file descriptor, it doesn't seem

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,9 +250,9 @@ async function mainCLI() {
 	[argv.display, argv.remove] = displayremoveToDisplayRemove(argv.displayremove);
 	delete argv.displayremove;
 
-    // Remap keys to be more javascript-friendly
-    argv = (({"syllable-precision": syllablePrecision, "minimum-progression-duration": minimumProgressionDuration, ...rest}) =>
-        ({syllablePrecision, minimumProgressionDuration, ...rest}))(argv)
+	// Remap keys to be more javascript-friendly
+	argv = (({"syllable-precision": syllablePrecision, "minimum-progression-duration": minimumProgressionDuration, ...rest}) =>
+		({syllablePrecision, minimumProgressionDuration, ...rest}))(argv);
 
 	// This should be updated to work on Windows, but it would involve some extra
 	// work because even though readFile can take a file descriptor, it doesn't seem

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -296,8 +296,8 @@ export default class KBPParser {
 			hpos,
 			alignment,
 			// Insert sentence syllables as objects or as a string
-			syllables: this.config["syllable-precision"] ? syllables : undefined,
-			text: this.config["syllable-precision"]
+			syllables: this.config.syllablePrecision ? syllables : undefined,
+			text: this.config.syllablePrecision
 				? ""
 				: syllables.map(s => s.text).join(""),
 			rotation

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -5,6 +5,7 @@ export default class KBPParser {
 	config: IConfig;
 	track: ISentence[] | undefined;
 	styles: IStyle[] = [];
+	fixedStyles: IStyle[] = [];
 
 	constructor(config: IConfig) {
 		this.config = config;
@@ -70,7 +71,6 @@ export default class KBPParser {
 		let horizontalPos = null;
 		let currentAlignment = null;
 		let defaultWipeProgressive = null;
-		let fixed = null;
 		let rotation = null;
 
 		let offsetms = Math.floor(this.config.offset * 1000);
@@ -177,11 +177,27 @@ export default class KBPParser {
 						(currentAlignment == 7 ? leftMargin : rightMargin) + 
 							(this.config.border ? 6 : 0));
 				if (element[2] !== "0" && element[3] !== "0") {
-					currentStyle = this.styles[element[1].toUpperCase().charCodeAt(0) - 65] ?? this.styles[0];
+					// Fixed text (no visibl wiping)
+					// Create styles on demand as used
+					if (element[1].toLowerCase() == element[1]) {
+						let fixedIndex = element[1].charCodeAt(0) - "a".charCodeAt(0);
+						fixedIndex = this.styles[fixedIndex] === undefined ? 0 : fixedIndex;
+						this.fixedStyles[fixedIndex] ??= {
+							...(this.styles[fixedIndex]),
+							Name: `${this.styles[fixedIndex].Name}_Fixed`,
+							// Color should be the "pre-wipe" color
+							PrimaryColour: this.styles[fixedIndex].SecondaryColour,
+							Alignment: undefined
+						};
+						currentStyle = this.fixedStyles[fixedIndex];
+					}
+					// Regular style
+					else {
+						currentStyle = this.styles[element[1].charCodeAt(0) - "A".charCodeAt(0)] ?? this.styles[0];
+					}
 					// Push the alignment from the first use of the style into the style
 					currentStyle.Alignment ||= currentAlignment;
 				}
-				fixed = (element[1].toLowerCase() == element[1]);
 				currentStart = Math.floor(parseInt(element[2]) * 10) + offsetms;
 				if (currentStart < 0) currentStart = 0;
 				currentEnd = Math.floor(parseInt(element[3]) * 10) + offsetms;
@@ -227,14 +243,10 @@ export default class KBPParser {
 
 				// Add the start time of the syllable
 
-				// TODO: Better handling of fixed text. Currently this will just set
-				// the time before wiping starts to be the duration of the line to stop it
-				// from ever wiping but ideally there should be a fixed version of the
-				// style that does not even use \k or \kf
-				syllable.start = fixed ? currentEnd : Math.floor(parseInt(matches[1].trim()) * 10 + offsetms);
+				syllable.start = Math.floor(parseInt(matches[1].trim()) * 10 + offsetms);
 				if (syllable.start < 0) syllable.start = 0;
 				// Add the duration, end time
-				syllable.end = fixed ? syllable.start : Math.floor(parseInt(matches[2].trim()) * 10 + offsetms);
+				syllable.end = Math.floor(parseInt(matches[2].trim()) * 10 + offsetms);
 				if (syllable.end < 0) syllable.end = 0;
 				syllable.duration = syllable.end - syllable.start;
 
@@ -295,11 +307,7 @@ export default class KBPParser {
 			vpos,
 			hpos,
 			alignment,
-			// Insert sentence syllables as objects or as a string
-			syllables: this.config.syllablePrecision ? syllables : undefined,
-			text: this.config.syllablePrecision
-				? ""
-				: syllables.map(s => s.text).join(""),
+			syllables,
 			rotation
 		};
 	}

--- a/src/kbp.ts
+++ b/src/kbp.ts
@@ -190,9 +190,7 @@ export default class KBPParser {
 							Alignment: undefined
 						};
 						currentStyle = this.fixedStyles[fixedIndex];
-					}
-					// Regular style
-					else {
+					} else { // Regular style
 						currentStyle = this.styles[element[1].charCodeAt(0) - "A".charCodeAt(0)] ?? this.styles[0];
 					}
 					// Push the alignment from the first use of the style into the style

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,4 @@
 interface IConfig {
-	syllablePrecision?: boolean;
 	wipe?: boolean;
 	position?: boolean;
 	border?: boolean;
@@ -84,7 +83,6 @@ interface ISentence {
 	vpos: number;
 	hpos: number;
 	alignment: number;
-	text: string;
 	duration: number;
 	rotation: number;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,17 +1,16 @@
 interface IConfig {
-	"full-mode"?: boolean;
-	"syllable-precision"?: boolean;
-	"wipe"?: boolean;
-	"position"?: boolean;
-	"border"?: boolean;
-	"cdg"?: boolean;
-	"minimum-progression-duration"?: number;
-	"dialogueScript"?: string;
-	"width"?: number;
-	"transparency"?: boolean;
-	"offset"?: number;
-	"display"?: number;
-	"remove"?: number;
+	syllablePrecision?: boolean;
+	wipe?: boolean;
+	position?: boolean;
+	border?: boolean;
+	cdg?: boolean;
+	minimumProgressionDuration?: number;
+	dialogueScript?: string;
+	width?: number;
+	transparency?: boolean;
+	offset?: number;
+	display?: number;
+	remove?: number;
 }
 
 interface IStyle {


### PR DESCRIPTION
- "syllable-precision" has been removed since it's not being used and there isn't really a good way to implement it anyway due to the way KBP handles "syllables".
- "minimum-progression-duration" has been renamed to the JS object-friendly minimumProgressionDuration
- Fixed text has been improved. It now creates a new style with the wipe color the same as the pre-wipe color